### PR TITLE
Create abstractions around http and websocket

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -31,11 +31,7 @@ export function* createServer(port: number, handler: RequestHandler, ready: Read
 }
 
 export class Response {
-  private inner: ServerResponse
-
-  constructor(response) {
-    this.inner = response;
-  }
+  constructor(private inner: ServerResponse) {}
 
   writeHead(statusCode: number, headers?: http.OutgoingHttpHeaders): http.ServerResponse {
     return this.inner.writeHead(statusCode, headers);

--- a/src/http.ts
+++ b/src/http.ts
@@ -2,11 +2,11 @@ import * as http from 'http';
 import { IncomingMessage, ServerResponse } from 'http';
 import { Execution, Operation, Sequence, fork } from 'effection';
 
-export { IncomingMessage, ServerResponse } from 'http';
+export { IncomingMessage } from 'http';
 
-import { getCurrentExecution } from './util';
+import { getCurrentExecution, resumeOnCb } from './util';
 
-export type RequestHandler = (req: IncomingMessage, res: ServerResponse) => Operation;
+export type RequestHandler = (req: IncomingMessage, res: Response) => Operation;
 export type ReadyCallback = (server: http.Server) => void;
 
 export function* createServer(port: number, handler: RequestHandler, ready: ReadyCallback = x => x): Sequence {
@@ -23,19 +23,31 @@ export function* createServer(port: number, handler: RequestHandler, ready: Read
   try {
     while (true) {
       let [request, response] = yield;
-      fork(handler(request, response));
+      fork(handler(request, new Response(response)));
     }
   } finally {
     server.close();
   }
 }
 
-export function end(res: ServerResponse, body: string): Operation {
-  return (execution: Execution<void>) => {
-    let fail = (error: Error) => execution.throw(error);
-    res.end(body, () => execution.resume());
+export class Response {
+  private inner: ServerResponse
 
-    return () => res.off("error", fail);
+  constructor(response) {
+    this.inner = response;
+  }
+
+  writeHead(statusCode: number, headers?: http.OutgoingHttpHeaders): http.ServerResponse {
+    return this.inner.writeHead(statusCode, headers);
+  };
+
+  end(body): Operation {
+    return (execution: Execution<void>) => {
+      let fail = (error: Error) => execution.throw(error);
+      this.inner.end(body, () => execution.resume());
+      this.inner.on("error", fail);
+      return () => this.inner.off("error", fail);
+    }
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { Execution, Operation, Sequence, fork, timeout } from 'effection';
-import { createServer, end, IncomingMessage, ServerResponse } from './http';
+import { createServer, IncomingMessage, Response } from './http';
 import { createSocketServer, Connection, Message } from './ws';
 import { AddressInfo } from 'net';
 
@@ -28,11 +28,11 @@ export function* main(): Sequence {
   // fork(buildServer);
 }
 
-function* commandServer(req: IncomingMessage, res: ServerResponse): Sequence {
+function* commandServer(req: IncomingMessage, res: Response): Sequence {
   res.writeHead(200, {
     'X-Powered-By': 'effection'
   });
-  yield end(res, "Your wish is my command\n");
+  yield res.end("Your wish is my command\n");
 }
 
 function* connectionServer(connection: Connection): Sequence {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
-import { fork, Execution } from 'effection';
+import { fork, Execution, Operation } from 'effection';
+import { EventEmitter } from 'events';
 
 const Fork = fork(function*() {}).constructor;
 
@@ -12,4 +13,37 @@ const Fork = fork(function*() {}).constructor;
  */
 export function getCurrentExecution(): Execution {
   return Fork["currentlyExecuting"] as Execution;
+}
+
+/**
+ * Takes the common Node pattern of a callback with an error
+ * parameter, and wraps it to return a yieldable Operation
+ * instead.
+ */
+export function resumeOnCb(fn: (cb: (error: Error) => void) => void): Operation {
+  return (execution: Execution<void>) => {
+    let iCare = true;
+    fn((error: Error) => {
+      if (iCare) {
+        if (error) {
+          execution.throw(error);
+        } else {
+          execution.resume();
+        }
+      }
+    });
+    return () => iCare = false;
+  }
+}
+
+/**
+ * Takes an event emitter and event name and returns a yieldable
+ * operation which resumes when the event occurrs.
+ */
+export function resumeOnEvent(emitter: EventEmitter, eventName: string): Operation {
+  return (execution: Execution) => {
+    let resume = (event) => execution.resume(event);
+    emitter.on(eventName, resume);
+    return () => emitter.off(eventName, resume);
+  }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,7 +20,7 @@ export function getCurrentExecution(): Execution {
  * parameter, and wraps it to return a yieldable Operation
  * instead.
  */
-export function resumeOnCb(fn: (cb: (error: Error) => void) => void): Operation {
+export function resumeOnCb(fn: (cb: (error?: Error) => void) => void): Operation {
   return (execution: Execution<void>) => {
     let iCare = true;
     fn((error: Error) => {

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -1,13 +1,13 @@
 import { createServer } from 'http';
 import {
   server as WebSocketServer,
-  connection as Connection,
+  connection as WebSocketConnection,
   request as Request,
   IMessage as Message
 } from 'websocket';
 
 import { fork, Sequence, Operation, Execution } from 'effection';
-import { getCurrentExecution } from './util';
+import { getCurrentExecution, resumeOnCb, resumeOnEvent } from './util';
 
 import { listen, ReadyCallback } from './http';
 
@@ -33,7 +33,7 @@ export function* createSocketServer(port: number, handler: ConnectionHandler, re
 
   try {
     while (true) {
-      let connection: Connection = yield;
+      let connection: WebSocketConnection = yield;
 
       let handle = fork(function* setupConnection() {
         let halt = () => handle.halt();
@@ -41,7 +41,7 @@ export function* createSocketServer(port: number, handler: ConnectionHandler, re
         connection.on("error", fail);
         connection.on("close", halt);
         try {
-          yield handler(connection);
+          yield handler(new Connection(connection));
         } finally {
           connection.off("close", halt);
           connection.off("error", fail);
@@ -56,21 +56,23 @@ export function* createSocketServer(port: number, handler: ConnectionHandler, re
   }
 }
 
-function send(connection: Connection, data: string): Operation {
-  return (execution: Execution<void>) => {
-    let iCare = true;
-    connection.send(data, error => {
-      if (iCare) {
-        if (error) {
-          execution.throw(error);
-        } else {
-          execution.resume();
-        }
-      }
-    });
-    return () => iCare = false;
+
+class Connection {
+  private inner: WebSocketConnection;
+
+  constructor(connection: WebSocketConnection) {
+    this.inner = connection;
+  }
+
+  send(data: String): Operation {
+    return resumeOnCb((cb) => this.inner.send(data, cb));
+  }
+
+  receiveMessage() {
+    return resumeOnEvent(this.inner, "message");
   }
 }
-export { Connection, Message, send }
+
+export { Connection, Message }
 
 type ConnectionHandler = (conn: Connection) => Operation;

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -56,13 +56,8 @@ export function* createSocketServer(port: number, handler: ConnectionHandler, re
   }
 }
 
-
 class Connection {
-  private inner: WebSocketConnection;
-
-  constructor(connection: WebSocketConnection) {
-    this.inner = connection;
-  }
+  constructor(private inner: WebSocketConnection) {}
 
   send(data: String): Operation {
     return resumeOnCb((cb) => this.inner.send(data, cb));

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,9 +303,9 @@ doctrine@^3.0.0:
     esutils "^2.0.2"
 
 effection@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/effection/-/effection-0.3.2.tgz#a1dc32a8b247a73b34064ce24e2223edbb42a8d6"
-  integrity sha512-X1YPh5JNdlb2pRSV57vofRh9Vou90rMB3+i1lpsOIlFph9Ldhm7Z8hWysrm13oCD6cPeDzhSbQH/UWPYcZDJ+w==
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/effection/-/effection-0.3.3.tgz#418de2698fe8bc9ef4cdee065b01730ed22bc601"
+  integrity sha512-JP7t68WyLfUgFBfRFBDA0eP7PLV8VqIzFN1d441op/ENXDslDFfTC5w8STDAC10L9SqMywC+zvTbVtx9R0eCqQ==
 
 emoji-regex@^7.0.1:
   version "7.0.3"


### PR DESCRIPTION
Instead of using free functions, this starts wrapping the interior APIs of http and websocket so we can use them with effection's yield.

This is pretty rudimentary in that it only adds the operations we're currently using. It seems like eventually we'll want to extract all of this into effection-http and effection-websocket libraries, I guess?