### PR TITLE
Ignore Node Version File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /yarn-error.log
+.node-version


### PR DESCRIPTION
Don't want to put in any time into switching node version switcher (is there a version switcher switcher?), so I'll stick with nodenv for now, and ignoring this file seems to be the most sensible way here.