### PR TITLE
Add watch command to watch

### DIFF
--- a/bin/watch.ts
+++ b/bin/watch.ts
@@ -1,0 +1,95 @@
+import * as cp from 'child_process';
+import * as fs from 'fs';
+import { fork, Sequence } from 'effection';
+
+import { EventEmitter } from '../src/util';
+
+function* watch(): Sequence {
+  let [ cmd, ...args ] = process.argv.slice(2);
+
+  let listener = fork(function* changes() {
+    let watcher = FileWatcher.watch('src', { recursive: true });
+    try {
+      while (true) {
+        yield watcher.on("change");
+        console.log('change detected, restarting....');
+        restart();
+      }
+    } finally {
+      watcher.close();
+    }
+  });
+
+  let current = { halt() {} };
+  let restart = () => {
+    current.halt();
+    current = this.fork(function*() {
+      try {
+        yield launch(cmd, args);
+        listener.halt();
+      } catch (error) {
+        console.log(error);
+      }
+    })
+  };
+
+  restart();
+}
+
+
+
+class FileWatcher extends EventEmitter<fs.FSWatcher, "change"> {
+  static watch(filename: string, options: any) {
+    return new FileWatcher(fs.watch(filename, options));
+  }
+
+  close() {
+    this.inner.close();
+  }
+}
+
+class ChildProcess extends EventEmitter<cp.ChildProcess, "error" | "exit"> {
+  static spawn(cmd: string, args: string[] = [], options: cp.SpawnOptions) {
+    return new ChildProcess(cp.spawn(cmd, args, options));
+  }
+
+  kill(signal?: string) {
+    this.inner.kill(signal);
+  }
+}
+
+function* launch(cmd: string, args: string[]): Sequence {
+  let child = ChildProcess.spawn(cmd, args, { stdio: 'inherit'});
+
+  fork(function*() {
+    let errors = fork(function*() {
+      let [ error ] = yield child.on("error");
+      throw error;
+    });
+
+    try {
+      let [ code ] = yield child.on('exit');
+      errors.halt();
+
+      if (code > 0) {
+        throw new Error(`exited with code ${code}`)
+      }
+    } finally {
+      child.kill();
+    }
+  })
+
+
+}
+
+fork(function* main() {
+  let interrupt = () => { console.log('');  this.halt()};
+  process.on('SIGINT', interrupt);
+  try {
+    yield watch;
+  } catch (e) {
+    console.log(e);
+  } finally {
+    process.off('SIGINT', interrupt);
+  }
+});


### PR DESCRIPTION
When developing a daemon, it's nice to not have to constantly kill and
restart it when making a change.

This introduces a new command: `yarn watch` which will persistently
watch the command specified in its arguments and restart that command
whenever anything in the `src/` directory is changed.