### PR TITLE
🚨Linting capability

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,11 @@
+on: push
+name: Node Code Formatter
+jobs:
+  lint:
+    name: Node Code Formatter
+    runs-on: ubuntu-latest
+    steps:
+    - name: Node Code Formatter
+      uses: MarvinJWendt/run-node-formatter@1.5.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.JACK_TOKEN }}

--- a/bin/watch.ts
+++ b/bin/watch.ts
@@ -20,7 +20,7 @@ function* watch(): Sequence {
     }
   });
 
-  let current = { halt() {} };
+  let current = { halt: (x = undefined) => x };
   let restart = () => {
     current.halt();
     current = this.fork(function*() {
@@ -38,8 +38,16 @@ function* watch(): Sequence {
 
 
 
+interface WatchOptions {
+  encoding?: BufferEncoding | null;
+  persistent?: boolean;
+  recursive?: boolean;
+}
+
+type WatchOptionsType = WatchOptions | BufferEncoding | undefined | null;
+
 class FileWatcher extends EventEmitter<fs.FSWatcher, "change"> {
-  static watch(filename: string, options: any) {
+  static watch(filename: string, options: WatchOptionsType) {
     return new FileWatcher(fs.watch(filename, options));
   }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "start": "ts-node bin/start.ts"
+    "start": "ts-node bin/start.ts",
+    "lint": "eslint src/**/*.ts bin/**/*.ts"
   },
   "devDependencies": {
     "@types/websocket": "^1.0.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Execution, Operation, Sequence, fork, timeout } from 'effection';
+import { Sequence, fork, timeout } from 'effection';
 import { createServer, IncomingMessage, Response } from './http';
 import { createSocketServer, Connection, Message } from './ws';
 import { AddressInfo } from 'net';

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
 import { fork, Execution, Operation } from 'effection';
 import * as events from 'events';
 
+//eslint-disable-next-line @typescript-eslint/no-empty-function
 const Fork = fork(function*() {}).constructor;
 
 /**

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -6,7 +6,7 @@ import {
   IMessage as Message
 } from 'websocket';
 
-import { fork, Sequence, Operation, Execution } from 'effection';
+import { fork, Sequence, Operation } from 'effection';
 import { getCurrentExecution, resumeOnCb, EventEmitter } from './util';
 
 import { listen, ReadyCallback } from './http';
@@ -47,7 +47,7 @@ export function* createSocketServer(port: number, handler: ConnectionHandler, re
           connection.off("error", fail);
           connection.close();
         }
-      }) as any;
+      });
 
     }
   } finally {
@@ -59,7 +59,7 @@ export function* createSocketServer(port: number, handler: ConnectionHandler, re
 type ConnectionEvent = "message" | "frame" | "close" | "error" | "drain" | "pause" | "resume" | "ping" | "pong";
 
 class Connection extends EventEmitter<WebSocketConnection, ConnectionEvent> {
-  send(data: String): Operation {
+  send(data: string): Operation {
     return resumeOnCb((cb) => this.inner.send(data, cb));
   }
 }


### PR DESCRIPTION
We already have eslint installed to enforce a consistent style. We just don't actually run it formally. In addition to fixing all of the existing listing errors, this also introduces a github workflow to automatically lint (and fix) any errors that we detect using the [Node Code Formatter][1] action.

obsoletes #9 

[1]: https://github.com/marketplace/actions/node-code-formatter