### PR TITLE
🐛Properly escape linting globs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "ts-node -r module-alias/register bin/start.ts",
     "watch": "ts-node -r module-alias/register bin/watch.ts",
-    "lint": "eslint src/**/*.ts bin/**/*.ts"
+    "lint": "eslint 'src/**/*.ts' 'bin/**/*.ts'"
   },
   "devDependencies": {
     "@types/websocket": "^1.0.0",


### PR DESCRIPTION
Running the command through `yarn` was not properly passing the dirglobs like `src/**/*.ts` through to `eslint`. As a result, none of our files were actually getting linted.

Enquoting them makes sure that each is passed unexpanded to `eslint`.