### PR TITLE
Document the `watch` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,30 @@
 To run the server:
 
 ``` sh
-yarn watch yarn start
+$ yarn start
 ```
 
 Then open the following URL in a browser:
 
 <http://localhost:24004/index.html?orchestrator=ws%3A%2F%2Flocalhost%3A24003>
 
+
 To run the tests:
 
+``` sh
+$ yarn test
 ```
-yarn test
+
+During development, you can use the `watch` script to watch any
+process and restart it when the source files are changed. To watch and
+restart a running server:
+
+``` sh
+$ yarn watch yarn start
+```
+
+To watch and restart the tests:
+
+``` sh
+$ yarn watch yarn test
 ```


### PR DESCRIPTION
The `watch` script can be used to restart _any_ process, not just the server process, but that isn't really apparent from the README.

This adds a few different examples to help explain it.