### PR TITLE
Make watch and watchError return controllers

### DIFF
--- a/src/effection/events.ts
+++ b/src/effection/events.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { Execution } from 'effection';
+import { Controller } from 'effection';
 
 type EventName = string | symbol;
 
@@ -7,34 +7,40 @@ type EventName = string | symbol;
  * Takes an event emitter and event name and returns a yieldable
  * operation which resumes when the event occurrs.
  */
-export function on(emitter: EventEmitter, eventName: EventName) {
-  return (execution: Execution) => {
+export function on(emitter: EventEmitter, eventName: EventName): Controller {
+  return (execution) => {
     let resume = (...args: unknown[]) => execution.resume(args);
     emitter.on(eventName, resume);
     return () => emitter.off(eventName, resume);
   }
 }
 
-export function watch(execution: Execution, emitter: EventEmitter, names: EventName | EventName[]) {
-  for(let name of [].concat(names)) {
-    let listener = (...args) => {
-      execution.send({ event: name, args: args });
-    }
+export function watch(emitter: EventEmitter, names: EventName | EventName[]): Controller {
+  return (execution) => {
+    for(let name of [].concat(names)) {
+      let listener = (...args) => {
+        execution.send({ event: name, args: args });
+      }
 
-    emitter.on(name, listener);
-    execution.atExit(() => {
-      emitter.off(name, listener);
-    });
+      emitter.on(name, listener);
+      execution.atExit(() => {
+        emitter.off(name, listener);
+      });
+    }
+    execution.resume(emitter);
   }
 }
 
-export function watchError(execution: Execution, emitter: EventEmitter) {
-  let listener = (error) => {
-    execution.throw(error);
-  }
+export function watchError(emitter: EventEmitter): Controller {
+  return (execution) => {
+    let listener = (error) => {
+      execution.throw(error);
+    }
 
-  emitter.on("error", listener);
-  execution.atExit(() => {
-    emitter.off("error", listener);
-  });
+    emitter.on("error", listener);
+    execution.atExit(() => {
+      emitter.off("error", listener);
+    });
+    execution.resume(emitter);
+  }
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -24,7 +24,7 @@ export function createProxyServer(orchestrator: Execution, options: ProxyOptions
     let contentType = proxyRes.headers['content-type'] as string;
     let contentEncoding = proxyRes.headers['content-encoding'] as string;
 
-    watchError(this, proxyRes);
+    yield watchError(proxyRes);
 
     if(contentType && contentType.split(';')[0] === 'text/html') {
       res.removeHeader('content-length');
@@ -35,8 +35,8 @@ export function createProxyServer(orchestrator: Execution, options: ProxyOptions
       let tr = trumpet();
       let unzip = zlib.createGunzip();
 
-      watchError(this, tr);
-      watchError(this, unzip);
+      yield watchError(tr);
+      yield watchError(unzip);
 
       tr.select('head', (node) => {
         let rs = node.createReadStream();
@@ -77,7 +77,7 @@ export function createProxyServer(orchestrator: Execution, options: ProxyOptions
     });
     this.atExit(() => proxyServer.close());
 
-    watch(this, proxyServer, ['proxyRes', 'error', 'open', 'close']);
+    yield watch(proxyServer, ['proxyRes', 'error', 'open', 'close']);
 
     let server = http.createServer();
     this.atExit(() => server.close());


### PR DESCRIPTION
We're moving in a direction where the only way of getting an execution is via controllers, and so using `this` feels like an anti-pattern. This is more in-line with how we imagine idiomatic effection code to look like in the future.