### PR TITLE
We need to set execArgv because ts-node changes it

### DIFF
--- a/src/agent-server.ts
+++ b/src/agent-server.ts
@@ -14,6 +14,7 @@ export function* createAgentServer(orchestrator: Execution, options: AgentServer
     ['-p', `${options.port}`, 'agent/index.html', 'agent/harness.ts'],
     {
       execPath: 'ts-node',
+      execArgv: [],
       stdio: ['pipe', 'pipe', 'pipe', 'ipc']
     }
   );


### PR DESCRIPTION
This works differently depending on whether we run via ts-node or mocha, so to work with both we need a baseline which works in either case. ts-node sets execArgv, while mocha does not.