### PR TITLE
Lazily start orchestrator and improve test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "ts-node -r module-alias/register bin/start.ts",
     "watch": "ts-node -r module-alias/register bin/watch.ts",
     "lint": "eslint 'src/**/*.ts' 'bin/**/*.ts' 'agent/**/*.ts'",
-    "test": "mocha -r module-alias/register -r ts-node/register test/**/*.test.ts",
+    "test": "mocha -r ./test/setup test/**/*.test.ts",
+    "mocha": "mocha -r ./test/setup",
     "test:app:start": "cd test/app && react-scripts start",
     "test:app:build": "cd test/app && react-scripts build"
   },

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,54 +1,18 @@
-import { AbortController } from 'abort-controller';
-import fetch, { Response } from 'node-fetch';
-import { fork, receive, Execution, Operation } from 'effection';
+import { Response } from 'node-fetch';
+import { receive, Execution, Operation } from 'effection';
+import { World } from './helpers/world';
 
 import { beforeEach, afterEach } from 'mocha';
-
-import { setLogLevel } from '../src/log-level';
 
 import { createOrchestrator } from '../src/index';
 
 interface Actions {
   fork(operation: Operation): Execution;
   get(url: string): Promise<Response>;
+  startOrchestrator(): Promise<Execution>;
 }
 
-class World {
-  execution: Execution;
-  constructor() {
-    this.execution = fork(function*() { yield; });
-  }
-
-  destroy() {
-    this.execution.halt();
-  }
-
-  fork(operation: Operation): Execution {
-    return (this.execution as any).fork(operation);
-  }
-
-  get(url: string): Promise<Response>{
-    return this.request('get', url);
-  }
-
-  request(method: RequestMethod, url: string): Promise<Response> {
-    let controller = new AbortController();
-    let { signal } = controller;
-    let result = fetch(url, { method, signal });
-
-    this.fork(function* abortListener() {
-      try {
-        yield result;
-      } finally {
-        controller.abort();
-      }
-    });
-
-    return result;
-  }
-}
-
-type RequestMethod = 'post' | 'get';
+let orchestratorPromise;
 
 export const actions: Actions = {
   fork(operation: Operation): Execution {
@@ -58,40 +22,37 @@ export const actions: Actions = {
   get(url: string): Promise<Response> {
     return currentWorld.get(url);
   },
+
+  startOrchestrator() {
+    if(!orchestratorPromise) {
+      orchestratorPromise = globalWorld.fork(function*() {
+        yield receive({ ready: "orchestrator" });
+      });
+
+      globalWorld.fork(createOrchestrator({
+        delegate: orchestratorPromise,
+        appCommand: "react-scripts start",
+        appEnv: { "PORT": "24100", "BROWSER": "none" },
+        appDir: "test/app",
+        appPort: 24100,
+        proxyPort: 24101,
+        commandPort: 24102,
+        connectionPort: 24103,
+        agentPort: 24104,
+      }));
+    }
+    return orchestratorPromise;
+  }
 }
 
 let globalWorld = new World();
 let currentWorld: World;
-let info: (...args: unknown[]) => void;
-
-before(async function() {
-  this.timeout(20000);
-  setLogLevel("warn");
-  let readiness = globalWorld.fork(function*() {
-    yield receive({ ready: "orchestrator" });
-  });
-
-  globalWorld.fork(createOrchestrator({
-    delegate: readiness,
-    appCommand: "react-scripts start",
-    appEnv: { "PORT": "24100", "BROWSER": "none" },
-    appDir: "test/app",
-    appPort: 24100,
-    proxyPort: 24101,
-    commandPort: 24102,
-    connectionPort: 24103,
-    agentPort: 24104,
-  }));
-
-  await readiness;
-});
 
 after(async function() {
   globalWorld.destroy();
 });
 
 beforeEach(() => {
-  setLogLevel("warn");
   currentWorld = new World();
 });
 

--- a/test/helpers/world.ts
+++ b/test/helpers/world.ts
@@ -1,0 +1,34 @@
+import { fork, Execution, Operation } from 'effection';
+import fetch, { Response } from 'node-fetch';
+import { AbortController } from 'abort-controller';
+
+type RequestMethod = 'post' | 'get';
+
+export class World {
+  execution: Execution;
+  constructor() {
+    this.execution = fork(function*() { yield; });
+  }
+
+  destroy() {
+    this.execution.halt();
+  }
+
+  fork(operation: Operation): Execution {
+    return (this.execution as any).fork(operation);
+  }
+
+  get(url: string): Promise<Response>{
+    return this.request('get', url);
+  }
+
+  request(method: RequestMethod, url: string): Promise<Response> {
+    let controller = new AbortController();
+    let { signal } = controller;
+    let result = fetch(url, { method, signal });
+
+    this.execution.atExit(() => controller.abort());
+
+    return result;
+  }
+}

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -6,6 +6,11 @@ import { Response } from 'node-fetch';
 import { actions } from './helpers';
 
 describe('orchestrator', () => {
+  beforeEach(async function() {
+    this.timeout(20000);
+    await actions.startOrchestrator();
+  });
+
   describe('connecting to the command server', () => {
     let response: Response;
     let body: string;

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,7 @@
+require('module-alias/register');
+require('ts-node/register');
+process = require('process');
+
+let { setLogLevel } = require('../src/log-level')
+
+setLogLevel(process.env.LOG_LEVEL || 'warn');


### PR DESCRIPTION
This allows us to not start the orchestrator if we don't really need to.