### PR TITLE
Add a notion of state to the Orchestrator

### DIFF
--- a/agent/agent.ts
+++ b/agent/agent.ts
@@ -1,3 +1,5 @@
+import * as Bowser from 'bowser';
+
 function parseQueryParams(params) {
   return params
     .replace(/^\?/, "")
@@ -23,7 +25,10 @@ if(orchestrator) {
   let socket = new WebSocket(orchestrator);
 
   socket.addEventListener('open', () => {
-    socket.send('websocket message from agent');
+    socket.send(JSON.stringify({
+      type: 'connected',
+      data: Bowser.parse(navigator.userAgent)
+    }));
     console.log('[agent] socket connection established');
   });
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@types/mocha": "^5.2.7",
     "@types/node-fetch": "^2.5.3",
+    "@types/ramda": "types/npm-ramda#dist",
     "@typescript-eslint/eslint-plugin": "^2.3.2",
     "@typescript-eslint/parser": "^2.3.2",
     "abort-controller": "^3.0.0",
@@ -40,6 +41,7 @@
     "@types/http-proxy": "^1.17.0",
     "@types/node": "^12.7.11",
     "@types/websocket": "^1.0.0",
+    "bowser": "^2.8.1",
     "chokidar": "^3.3.1",
     "effection": "^0.4.0-a3f2e20",
     "express": "^4.17.1",
@@ -50,6 +52,7 @@
     "module-alias": "^2.2.2",
     "parcel": "^1.12.4",
     "parcel-bundler": "^1.12.4",
+    "ramda": "^0.26.1",
     "rimraf": "^3.0.0",
     "tempy": "^0.3.0",
     "trumpet": "^1.7.2",

--- a/src/connection-server.ts
+++ b/src/connection-server.ts
@@ -1,18 +1,28 @@
-import { Sequence, Execution, Operation, fork, timeout } from 'effection';
-import { on } from '@effection/events';
+import { Sequence, Execution, Operation, fork, receive, timeout, any } from 'effection';
+import { watch } from '@effection/events';
 
-import { createSocketServer, Connection, Message, send } from './ws';
+import { createSocketServer, Connection, send } from './ws';
+import { State } from './orchestrator/state';
+
+import { lensPath, assoc, dissoc } from 'ramda';
 
 interface ConnectionServerOptions {
+  state: State;
   port: number;
   proxyPort: number;
   testFilePort: number;
 };
 
+const agentsLens = lensPath(['agents']);
+
 export function createConnectionServer(orchestrator: Execution, options: ConnectionServerOptions): Operation {
   return function *connectionServer(): Sequence {
     function* handleConnection(connection: Connection): Sequence {
-      console.log('connection established');
+      console.debug('[connection] connected');
+      yield watch(connection, "message", (message) => {
+        return { message: JSON.parse(message.utf8Data) };
+      });
+
       fork(function* heartbeat() {
         while (true) {
           yield timeout(10000);
@@ -28,13 +38,21 @@ export function createConnectionServer(orchestrator: Execution, options: Connect
         }));
       });
 
+      let { message: { data } } = yield receive({ message: { type: 'connected' } });
+
+      let identifier = data.browser.name;
+
       try {
+        console.debug('[connection] received connection message', data);
+        options.state.over(agentsLens, assoc(identifier, data));
+
         while (true) {
-          let [message]: [Message] = yield on(connection, "message");
-          console.log(`mesage = `, message);
+          let message = yield receive({ message: any });
+          console.debug("[connection] got message", message);
         }
       } finally {
-        console.log('connection closed');
+        options.state.over(agentsLens, dissoc(identifier));
+        console.debug('[connection] disconnected');
       }
     }
     yield createSocketServer(options.port, handleConnection, () => {

--- a/src/effection/events.ts
+++ b/src/effection/events.ts
@@ -15,11 +15,19 @@ export function on(emitter: EventEmitter, eventName: EventName): Controller {
   }
 }
 
-export function watch(emitter: EventEmitter, names: EventName | EventName[]): Controller {
+function defaultPrepareMessage(...args) {
+  return { event: this.event, args: args };
+}
+
+export function watch(
+  emitter: EventEmitter,
+  names: EventName | EventName[],
+  prepare: (...args: any[]) => any = defaultPrepareMessage // eslint-disable-line @typescript-eslint/no-explicit-any
+): Controller {
   return (execution) => {
     for(let name of [].concat(names)) {
       let listener = (...args) => {
-        execution.send({ event: name, args: args });
+        execution.send(prepare.apply({ event: name }, args));
       }
 
       emitter.on(name, listener);

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -8,6 +8,8 @@ import { createAppServer } from './app-server';
 import { createTestFileWatcher } from './test-file-watcher';
 import { createTestFileServer } from './test-file-server';
 
+import { State } from './orchestrator/state';
+
 type OrchestratorOptions = {
   appPort: number;
   appCommand: string;
@@ -27,6 +29,7 @@ type OrchestratorOptions = {
 export function createOrchestrator(options: OrchestratorOptions): Operation {
   return function *orchestrator(): Sequence {
     let orchestrator = this; // eslint-disable-line @typescript-eslint/no-this-alias
+    let state = new State();
 
     console.log('[orchestrator] starting');
 
@@ -41,6 +44,7 @@ export function createOrchestrator(options: OrchestratorOptions): Operation {
     }));
 
     fork(createConnectionServer(orchestrator, {
+      state: state,
       port: options.connectionPort,
       proxyPort: options.proxyPort,
       testFilePort: options.testFilePort,

--- a/src/orchestrator/state.ts
+++ b/src/orchestrator/state.ts
@@ -1,0 +1,51 @@
+import { view, set, over } from 'ramda';
+
+export type AgentState = {
+  browser: {
+    name: string;
+    version: string;
+  };
+  os: {
+    name: string;
+    version: string;
+    versionName: string;
+  };
+  platform: {
+    type: string;
+    vendor: string;
+  };
+  engine: {
+    name: string;
+    version: string;
+  };
+}
+
+export type OrchestratorState = {
+  agents: Record<string, AgentState>;
+}
+
+export class State {
+  state: OrchestratorState = {
+    agents: {}
+  }
+
+  get(): OrchestratorState {
+    return this.state;
+  }
+
+  update(fn: (OrchestratorState) => OrchestratorState): void {
+    this.state = fn(this.state);
+  }
+
+  view(lens) {
+    return view(lens, this.get());
+  }
+
+  set(lens, value) {
+    this.update((state) => set(lens, value, state) as unknown as OrchestratorState);
+  }
+
+  over(lens, fn) {
+    this.update((state) => over(lens, fn, state) as unknown as OrchestratorState);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2141,6 +2141,10 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
+"@types/ramda@types/npm-ramda#dist":
+  version "0.25.0"
+  resolved "https://codeload.github.com/types/npm-ramda/tar.gz/9529aa3c8ff70ff84afcbc0be83443c00f30ea90"
+
 "@types/range-parser@*":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
@@ -3100,6 +3104,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
+bowser@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.8.1.tgz#35b74165e17b80ba8af6aa4736c2861b001fc09e"
+  integrity sha512-FxxltGKqMHkVa3KtpA+kdnxH0caHPDewccyrK3vW1bsMw6Zco4vRPmMunowX0pXlDZqhxkKSpToADQI2Sk4OeQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -10045,6 +10054,11 @@ raf@^3.4.1:
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
   dependencies:
     performance-now "^2.1.0"
+
+ramda@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"


### PR DESCRIPTION
The orchestrator allocates an object of type State which is basically a state container. This is sort of similar to state in React in that we have one method of updating the state, which takes the current state and returns a new state object.

Any manipulation of state is supposed to be pure, and not make mutative changes to the current state. To facilitate this we're using lenses as provided by the Ramda library. I've also added a few helper functions on `State` to make it easier to work with lenses.

This implementation has a few benefits:

- State is localized to one single store, rather than being spread out over the entire app.
- Any change to state must go through the `update` method, which means it should be fairly simple to add watch queries and similar which depend on changing state.