### PR TITLE
✨Make the Command server speak GraphQL

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,17 @@
     "todomvc-app-css": "^2.0.6"
   },
   "dependencies": {
+    "http-proxy": "^1.18.0",
     "@types/express": "^4.17.1",
+    "@types/graphql": "^14.5.0",
     "@types/http-proxy": "^1.17.0",
     "@types/node": "^12.7.11",
     "@types/websocket": "^1.0.0",
     "chokidar": "^3.3.1",
     "effection": "^0.4.0-a3f2e20",
+    "express": "^4.17.1",
+    "express-graphql": "^0.9.0",
+    "graphql": "^14.5.8",
     "glob": "^7.1.6",
     "http-proxy": "^1.18.0",
     "module-alias": "^2.2.2",

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,58 +1,10 @@
 import * as http from 'http';
-import { IncomingMessage, ServerResponse } from 'http';
-import { Operation, Sequence, fork } from 'effection';
+import { Operation, fork } from 'effection';
 import { on } from '@effection/events';
 
 export { IncomingMessage } from 'http';
 
-import { resumeOnCb } from './util';
-
-export type RequestHandler = (req: IncomingMessage, res: Response) => Operation;
 export type ReadyCallback = (server: http.Server) => void;
-
-export function* createServer(port: number, handler: RequestHandler, ready: ReadyCallback = x => x): Sequence {
-  let server = http.createServer();
-
-  yield listen(server, port);
-
-  ready(server);
-
-  try {
-    while (true) {
-      let [request, response]: [IncomingMessage, ServerResponse] = yield on(server, "request");
-      fork(function* outerRequestHandler() {
-        let requestErrorMonitor = fork(function* () {
-          let [error]: [Error] = yield on(request, "error");
-          throw error;
-        });
-        let responseErrorMonitor = fork(function* () {
-          let [error]: [Error] = yield on(response, "error");
-          throw error;
-        });
-        try {
-          yield handler(request, new Response(response));
-        } finally {
-          requestErrorMonitor.halt();
-          responseErrorMonitor.halt();
-        }
-      });
-    }
-  } finally {
-    server.close();
-  }
-}
-
-export class Response {
-  constructor(private inner: ServerResponse) {}
-
-  writeHead(statusCode: number, headers?: http.OutgoingHttpHeaders): http.ServerResponse {
-    return this.inner.writeHead(statusCode, headers);
-  };
-
-  end(body: string): Operation {
-    return resumeOnCb((cb) => this.inner.end(body, cb));
-  }
-}
 
 export function* listen(server: http.Server, port: number): Operation {
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,0 +1,9 @@
+import { buildSchema } from 'graphql';
+
+export const schema =  buildSchema(`
+
+type Query {
+  echo(text: String!): String
+}
+
+`);

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -15,8 +15,8 @@ describe('orchestrator', () => {
     let response: Response;
     let body: string;
     beforeEach(async () => {
-      response = await actions.get('http://localhost:24102');
-      body = await response.text();
+      response = await actions.get('http://localhost:24102?query={echo(text:"Hello World")}');
+      body = await response.json();
     });
 
     it('responds successfully', () => {
@@ -24,7 +24,7 @@ describe('orchestrator', () => {
     });
 
     it('contains the ping text', () => {
-      expect(body).toContain('Your wish is my command');
+      expect(body).toEqual({"data": {"echo": "Hello World"}})
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2060,6 +2060,13 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/graphql@^14.5.0":
+  version "14.5.0"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.5.0.tgz#a545fb3bc8013a3547cf2f07f5e13a33642b75d6"
+  integrity sha512-MOkzsEp1Jk5bXuAsHsUi6BVv0zCO+7/2PTiZMXWDSsMXvNU6w/PLMQT2vHn8hy2i0JqojPz1Sz6rsFjHtsU0lA==
+  dependencies:
+    graphql "*"
+
 "@types/http-proxy@^1.17.0":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.0.tgz#baf82ff6aa2723fd29f90e3ba1384e665006863e"
@@ -2427,7 +2434,7 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
+accepts@^1.3.7, accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
   integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
@@ -3818,7 +3825,7 @@ content-disposition@0.5.3:
   dependencies:
     safe-buffer "5.1.2"
 
-content-type@~1.0.4:
+content-type@^1.0.4, content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
@@ -5166,6 +5173,16 @@ expect@^24.9.0:
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
 
+express-graphql@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/express-graphql/-/express-graphql-0.9.0.tgz#00fd8552f866bac5c9a4612b2c4c82076107b3c2"
+  integrity sha512-wccd9Lb6oeJ8yHpUs/8LcnGjFUUQYmOG9A5BNLybRdCzGw0PeUrtBxsIR8bfiur6uSW4OvPkVDoYH06z6/N9+w==
+  dependencies:
+    accepts "^1.3.7"
+    content-type "^1.0.4"
+    http-errors "^1.7.3"
+    raw-body "^2.4.1"
+
 express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
@@ -5833,6 +5850,13 @@ grapheme-breaker@^0.3.2:
     brfs "^1.2.0"
     unicode-trie "^0.3.1"
 
+graphql@*, graphql@^14.5.8:
+  version "14.5.8"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.5.8.tgz#504f3d3114cb9a0a3f359bbbcf38d9e5bf6a6b3c"
+  integrity sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==
+  dependencies:
+    iterall "^1.2.2"
+
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
@@ -6128,17 +6152,7 @@ http-errors@1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-http-errors@~1.6.2:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
-  integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.3"
-    setprototypeof "1.1.0"
-    statuses ">= 1.4.0 < 2"
-
-http-errors@~1.7.2:
+http-errors@1.7.3, http-errors@^1.7.3, http-errors@~1.7.2:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
   integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
@@ -6148,6 +6162,16 @@ http-errors@~1.7.2:
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
+
+http-errors@~1.6.2:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
+  integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
 
 "http-parser-js@>=0.4.0 <0.4.11":
   version "0.4.10"
@@ -6814,6 +6838,11 @@ istanbul-reports@^2.2.6:
   integrity sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==
   dependencies:
     handlebars "^4.1.2"
+
+iterall@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
+  integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
 jest-changed-files@^24.9.0:
   version "24.9.0"
@@ -10044,6 +10073,16 @@ raw-body@2.4.0:
   dependencies:
     bytes "3.1.0"
     http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
+
+raw-body@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.1.tgz#30ac82f98bb5ae8c152e67149dac8d55153b168c"
+  integrity sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==
+  dependencies:
+    bytes "3.1.0"
+    http-errors "1.7.3"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 


### PR DESCRIPTION
From https://github.com/bigtestjs/server/issues/29 and #34 

> Rather than implement our own command interpreter we'll get one for
> free using GraphQL. This will allow us to not only get a command a
> query language (and response payload) with little effort, but we'll
> be able to use all of the tooling surrounding the GraphQL
> ecosystem (like the interactive webshell)

This uses the `graphql-express` packgage [recommended by graphql.org][1] to implement a graphql endpoint that satisfies our requrements. It serves graphql over simple `GET` and `POST` requests that accept `application/json`, but if the request is for `html`, then it will server the `GraphiQL` IDE.

Since the raw http server is not used anymore, the code dedicated to it has been removed.

[1]: https://graphql.org/learn/serving-over-http/#node