### PR TITLE
Unwrap generator-based operations

### DIFF
--- a/src/command-server.ts
+++ b/src/command-server.ts
@@ -9,25 +9,23 @@ interface CommandServerOptions {
   port: number;
 };
 
-export function createCommandServer(orchestrator: Context, options: CommandServerOptions): Operation {
-  return function *commandServer(): Operation {
-    let app = createApp();
-    let server = app.listen(options.port);
+export function* createCommandServer(orchestrator: Context, options: CommandServerOptions): Operation {
+  let app = createApp();
+  let server = app.listen(options.port);
 
-    yield fork(function*() {
-      let [error]: [Error] = yield on(server, 'error');
-      throw error;
-    });
+  yield fork(function*() {
+    let [error]: [Error] = yield on(server, 'error');
+    throw error;
+  });
 
-    try {
-      yield on(server, 'listening');
+  try {
+    yield on(server, 'listening');
 
-      yield send({ ready: "command" }, orchestrator);
+    yield send({ ready: "command" }, orchestrator);
 
-      yield
-    } finally {
-      server.close();
-    }
+    yield
+  } finally {
+    server.close();
   }
 }
 

--- a/src/connection-server.ts
+++ b/src/connection-server.ts
@@ -15,48 +15,46 @@ interface ConnectionServerOptions {
 
 const agentsLens = lensPath(['agents']);
 
-export function createConnectionServer(orchestrator: Context, options: ConnectionServerOptions): Operation {
-  return function *connectionServer(): Operation {
-    function* handleConnection(connection: Connection): Operation {
-      console.debug('[connection] connected');
-      yield watch(connection, "message", (message) => {
-        return { message: JSON.parse(message.utf8Data) };
-      });
-
-      yield fork(function* heartbeat() {
-        while (true) {
-          yield timeout(10000);
-          yield sendData(connection, JSON.stringify({type: "heartbeat"}));
-        }
-      })
-
-      yield fork(function* sendRun() {
-        yield sendData(connection, JSON.stringify({
-          type: "open",
-          url: `http://localhost:${options.proxyPort}`,
-          manifest: `http://localhost:${options.testFilePort}/manifest.js`
-        }));
-      });
-
-      let { message: { data } } = yield receive({ message: { type: 'connected' } });
-
-      let identifier = data.browser.name;
-
-      try {
-        console.debug('[connection] received connection message', data);
-        options.state.over(agentsLens, assoc(identifier, data));
-
-        while (true) {
-          let message = yield receive({ message: any });
-          console.debug("[connection] got message", message);
-        }
-      } finally {
-        options.state.over(agentsLens, dissoc(identifier));
-        console.debug('[connection] disconnected');
-      }
-    }
-    yield createSocketServer(options.port, handleConnection, function*() {
-      yield send({ ready: "connection" }, orchestrator);
+export function* createConnectionServer(orchestrator: Context, options: ConnectionServerOptions): Operation {
+  function* handleConnection(connection: Connection): Operation {
+    console.debug('[connection] connected');
+    yield watch(connection, "message", (message) => {
+      return { message: JSON.parse(message.utf8Data) };
     });
+
+    yield fork(function* heartbeat() {
+      while (true) {
+        yield timeout(10000);
+        yield sendData(connection, JSON.stringify({type: "heartbeat"}));
+      }
+    })
+
+    yield fork(function* sendRun() {
+      yield sendData(connection, JSON.stringify({
+        type: "open",
+        url: `http://localhost:${options.proxyPort}`,
+        manifest: `http://localhost:${options.testFilePort}/manifest.js`
+      }));
+    });
+
+    let { message: { data } } = yield receive({ message: { type: 'connected' } });
+
+    let identifier = data.browser.name;
+
+    try {
+      console.debug('[connection] received connection message', data);
+      options.state.over(agentsLens, assoc(identifier, data));
+
+      while (true) {
+        let message = yield receive({ message: any });
+        console.debug("[connection] got message", message);
+      }
+    } finally {
+      options.state.over(agentsLens, dissoc(identifier));
+      console.debug('[connection] disconnected');
+    }
   }
+  yield createSocketServer(options.port, handleConnection, function*() {
+    yield send({ ready: "connection" }, orchestrator);
+  });
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -14,7 +14,7 @@ interface ProxyOptions {
   inject?: string;
 };
 
-export function createProxyServer(orchestrator: Context, options: ProxyOptions): Operation {
+export function* createProxyServer(orchestrator: Context, options: ProxyOptions): Operation {
   function* handleRequest(proxyRes, req, res): Operation {
     console.debug('[proxy]', 'start', req.method, req.url);
     for(let [key, value] of Object.entries(proxyRes.headers)) {
@@ -70,52 +70,50 @@ export function createProxyServer(orchestrator: Context, options: ProxyOptions):
     console.debug('[proxy]', 'finish', req.method, req.url);
   };
 
-  return function *proxyServer(): Operation {
-    let proxyServer = proxy.createProxyServer({
-      target: `http://localhost:${options.targetPort}`,
-      selfHandleResponse: true
-    });
+  let proxyServer = proxy.createProxyServer({
+    target: `http://localhost:${options.targetPort}`,
+    selfHandleResponse: true
+  });
 
-    yield watch(proxyServer, ['proxyRes', 'error', 'open', 'close']);
+  yield watch(proxyServer, ['proxyRes', 'error', 'open', 'close']);
 
-    let server = http.createServer();
+  let server = http.createServer();
 
-    server.on('request', (req, res) => proxyServer.web(req, res));
-    server.on('upgrade', (req, socket, head) => proxyServer.ws(req, socket, head));
+  server.on('request', (req, res) => proxyServer.web(req, res));
+  server.on('upgrade', (req, socket, head) => proxyServer.ws(req, socket, head));
 
 
-    try {
+  try {
 
-      yield listen(server, options.port);
-      yield send({ ready: 'proxy' }, orchestrator);
+    yield listen(server, options.port);
+    yield send({ ready: 'proxy' }, orchestrator);
 
-      while(true) {
-        let { event, args } = yield receive({ event: any("string") });
+    while(true) {
+      let { event, args } = yield receive({ event: any("string") });
 
-        if(event == "error") {
-          let [err,, res] = args;
-          res.writeHead(502, { 'Content-Type': 'text/plain' });
-          res.end(`Proxy error: ${err}`);
-        }
-
-        if(event == "open") {
-          console.debug('[proxy] socket connection opened');
-        }
-
-        if(event == "close") {
-          console.debug('[proxy] socket connection closed');
-        }
-
-        if(event == "proxyRes") {
-          let [proxyRes, req, res] = args;
-          yield fork(function*() {
-            yield handleRequest(proxyRes, req, res);
-          });
-        }
+      if(event == "error") {
+        let [err,, res] = args;
+        res.writeHead(502, { 'Content-Type': 'text/plain' });
+        res.end(`Proxy error: ${err}`);
       }
-    } finally {
-      proxyServer.close();
-      server.close();
+
+      if(event == "open") {
+        console.debug('[proxy] socket connection opened');
+      }
+
+      if(event == "close") {
+        console.debug('[proxy] socket connection closed');
+      }
+
+      if(event == "proxyRes") {
+        let [proxyRes, req, res] = args;
+        yield fork(function*() {
+          yield handleRequest(proxyRes, req, res);
+        });
+      }
     }
+  } finally {
+    proxyServer.close();
+    server.close();
   }
 };


### PR DESCRIPTION
When effection first started out, only generator functions were recognized as operations, not the generators themselves. Nowadays, we know that it's actually get `Generator` itself that is the heart of the operation, and that generator function is just a function that returns an Operation (the generator).

As such, there is no need to have a function that returns a generator function. We can just use a function that returns a generator.... or a generator function.

This change makes all of these operation generating functions directly into generators.