### PR TITLE
Print agent URL on start up

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -99,6 +99,11 @@ export function createOrchestrator(options: OrchestratorOptions): Operation {
 
     console.log("[orchestrator] running!");
 
+
+    let connectionUrl = `ws://localhost:${options.connectionPort}`;
+    let agentUrl = `http://localhost:${options.agentPort}/index.html?orchestrator=${encodeURIComponent(connectionUrl)}`
+    console.log(`[orchestrator] launch agents via: ${agentUrl}`);
+
     if(options.delegate) {
       options.delegate.send({ ready: "orchestrator" });
     }


### PR DESCRIPTION
This makes it far more discoverable.

Eventually we'll want to launch agents programmatically, but this way we at least have a decent way of doing this right now.