### PR TITLE
Prevent listener leaks, closes #67

### DIFF
--- a/src/effection/events.ts
+++ b/src/effection/events.ts
@@ -29,9 +29,8 @@ export function watch(
 
     for(let name of [].concat(names)) {
       let listener = (...args) => {
-        parentContext.spawn(fork(function*() {
-          yield send(prepare.apply({ event: name}, args), parentContext);
-        }));
+        let message = prepare.apply({ event: name}, args);
+        parentContext.spawn(fork(send(message, parentContext)));
       }
 
       emitter.on(name, listener);


### PR DESCRIPTION
Essentially this reverts `watch` to work more like it did before, where it only ever creates *one* listener, thus preventing leaks. 

I'm honestly not too sure why the listeners were leaking in the other implementation, I think it shouldn't be happening, but it might be some combination of this implementation using monitor and `on` together?

At any rate, this implementation is probably more performant, and easier to reason about, since we're not attaching and removing listeners all the time.

The downside is that we have to use `ensure` to get rid of the listener. We could use a monitor, but that seems like a bit on an anti pattern to me. We definitely want the detachment of the listener to be synchronous with shut-down of the Execution, so I think using ensure is better.