### PR TITLE
Add a websocket API to the command server

### DIFF
--- a/bin/query.ts
+++ b/bin/query.ts
@@ -1,23 +1,13 @@
-import { main, Operation } from 'effection';
+import { Operation } from 'effection';
+import { main } from '@effection/node';
 import { Client } from '../src/client';
 
-const self: Operation = ({ resume, context: { parent }}) => resume(parent);
-
 main(function* main() {
-  let context = yield self;
-  let interrupt = () => { context.halt()};
-  process.on('SIGINT', interrupt);
-  try {
-    let client: Client = yield Client.create('ws://localhost:24002');
+  let client: Client = yield Client.create('ws://localhost:24002');
 
-    let [ source ]  = process.argv.slice(2);
+  let [ source ]  = process.argv.slice(2);
 
-    let data = yield client.query(source);
+  let data = yield client.query(source);
 
-    console.log(JSON.stringify(data, null, 2));
-  } catch (e) {
-    console.error(e);
-  } finally {
-    process.off('SIGINT', interrupt);
-  }
+  console.log(JSON.stringify(data, null, 2));
 })

--- a/bin/query.ts
+++ b/bin/query.ts
@@ -1,0 +1,23 @@
+import { main, Operation } from 'effection';
+import { Client } from '../src/client';
+
+const self: Operation = ({ resume, context: { parent }}) => resume(parent);
+
+main(function* main() {
+  let context = yield self;
+  let interrupt = () => { context.halt()};
+  process.on('SIGINT', interrupt);
+  try {
+    let client: Client = yield Client.create('ws://localhost:24002');
+
+    let [ source ]  = process.argv.slice(2);
+
+    let data = yield client.query(source);
+
+    console.log(JSON.stringify(data, null, 2));
+  } catch (e) {
+    console.error(e);
+  } finally {
+    process.off('SIGINT', interrupt);
+  }
+})

--- a/bin/subscribe.ts
+++ b/bin/subscribe.ts
@@ -1,0 +1,25 @@
+import { main, Operation } from 'effection';
+import { Client } from '../src/client';
+
+const self: Operation = ({ resume, context: { parent }}) => resume(parent);
+
+main(function* main() {
+  let context = yield self;
+  let interrupt = () => { context.halt()};
+  process.on('SIGINT', interrupt);
+  try {
+    let client: Client = yield Client.create('ws://localhost:24002');
+
+    let [ source ]  = process.argv.slice(2);
+
+    yield client.subscribe(source, function*(data) {
+      console.log('==== new subscription result ==== ');
+      console.log(JSON.stringify(data, null, 2));
+    });
+
+  } catch (e) {
+    console.error(e);
+  } finally {
+    process.off('SIGINT', interrupt);
+  }
+})

--- a/bin/subscribe.ts
+++ b/bin/subscribe.ts
@@ -1,25 +1,14 @@
-import { main, Operation } from 'effection';
+import { Operation } from 'effection';
+import { main } from '@effection/node';
 import { Client } from '../src/client';
 
-const self: Operation = ({ resume, context: { parent }}) => resume(parent);
-
 main(function* main() {
-  let context = yield self;
-  let interrupt = () => { context.halt()};
-  process.on('SIGINT', interrupt);
-  try {
-    let client: Client = yield Client.create('ws://localhost:24002');
+  let client: Client = yield Client.create('ws://localhost:24002');
 
-    let [ source ]  = process.argv.slice(2);
+  let [ source ]  = process.argv.slice(2);
 
-    yield client.subscribe(source, function*(data) {
-      console.log('==== new subscription result ==== ');
-      console.log(JSON.stringify(data, null, 2));
-    });
-
-  } catch (e) {
-    console.error(e);
-  } finally {
-    process.off('SIGINT', interrupt);
-  }
+  yield client.subscribe(source, function*(data) {
+    console.log('==== new subscription result ==== ');
+    console.log(JSON.stringify(data, null, 2));
+  });
 })

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "scripts": {
     "start": "ts-node -r module-alias/register bin/start.ts",
     "watch": "ts-node -r module-alias/register bin/watch.ts",
+    "query": "ts-node -r module-alias/register bin/query.ts",
+    "subscribe": "ts-node -r module-alias/register bin/subscribe.ts",
     "lint": "eslint 'src/**/*.ts' 'bin/**/*.ts' 'agent/**/*.ts'",
     "test": "mocha -r ./test/setup test/**/*.test.ts",
     "mocha": "mocha -r ./test/setup",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,89 +1,95 @@
 import { w3cwebsocket as WebSocket } from 'websocket';
 import { EventEmitter } from 'events';
-import { monitor, Operation } from 'effection';
+import { monitor, Operation, Context } from 'effection';
 import { on } from './effection/events'
 
 import { Message, isErrorResponse, isDataResponse } from './protocol';
 
-const parent: Operation = ({ resume, context: { parent }}) => resume(parent);
-
 export class Client {
-  query: (source: string) => Operation;
-  subscribe: (source: string, forEach: (result: unknown) => Operation) => Operation;
+  responseIds = 0;
+  subscriptions = new EventEmitter();
 
-  static *create(url: string): Operation {
-    let { parent: context } = yield parent;
-
-    let client = new Client();
-    let subscriptions = new EventEmitter();
-    let socket = new WebSocket(url);
-    let responseIds = 0;
-
+  private constructor(private socket: WebSocket, context: Context) {
+    let { subscriptions } = this;
     socket.onopen = () => subscriptions.emit('open');
     socket.onclose = event => subscriptions.emit('close', event);
     socket.onmessage = event => subscriptions.emit('message', event);
     socket.onerror = event => subscriptions.emit('error', event);
-
-    context.ensure(() => {
+    context['ensure'](() => {
       socket.onopen = socket.onclose = socket.onmessage = socket.onerror = null;
       socket.close();
     });
 
-    context.spawn(monitor(function* () {
+    context['spawn'](monitor(function* () {
       let [error]: [Error] = yield on(subscriptions, 'error');
       throw error;
     }));
 
-    context.spawn(monitor(function* () {
+    context['spawn'](monitor(function* () {
       yield on(subscriptions, 'close');
       throw new Error('Socket closed on the remote end');
     }));
+  }
 
-    function* send<Command>(command: Command, handle: (next: () => Operation) => Operation) {
-      let responseId = `${responseIds++}`; //we'd want a UUID to avoid hijacking?
-      let request: Message = {...command, responseId};
+  static *create(url: string): Operation {
+    let client = new Client(new WebSocket(url), yield parent);
 
-      socket.send(JSON.stringify(request));
-
-      let next = function* getNextResponse() {
-        while (true) {
-          let [event]: [MessageEvent] = yield on(subscriptions, 'message');
-          let message: Message = JSON.parse(event.data);
-
-          if (message.responseId === responseId) {
-            if (isErrorResponse(message)) {
-              let messages = message.errors.map(error => error.message);
-              throw new Error(messages.join("\n"));;
-            }
-            if (isDataResponse(message)) {
-              return message.data;
-            } else {
-              console.warn('unknown response format: ', event.data);
-            }
-          }
-        }
-      }
-
-      return yield handle(next);
-    }
-
-    client.query = function query(source: string): Operation {
-      return send({ query: source }, function*(next) {
-        return yield next();
-      });
-    }
-
-    client.subscribe = function subscribe(source, forEach): Operation {
-      return send({ query: source, live: true }, function*(next) {
-        while (true) {
-          let response = yield next();
-          yield forEach(response);
-        }
-      })
-    }
-
-    yield on(subscriptions, 'open');
+    yield on(client.subscriptions, 'open');
 
     return client;
   }
+
+  query(source: string): Operation {
+    return this.send({ query: source }, next => next());
+  }
+
+  subscribe(source: string, forEach: (response: unknown) => Operation): Operation {
+    return this.send({ query: source, live: true }, function*(next) {
+      while (true) {
+        let response = yield next();
+        yield forEach(response);
+      }
+    })
+  }
+
+  *send(command: Query, handle: HandleResponse): Operation {
+    let responseId = `${this.responseIds++}`; //we'd want a UUID to avoid hijacking?
+    let request: Message = {...command, responseId};
+
+    this.socket.send(JSON.stringify(request));
+
+    let { subscriptions } = this;
+
+    let next = function* getNextResponse() {
+      while (true) {
+        let [event]: [MessageEvent] = yield on(subscriptions, 'message');
+        let message: Message = JSON.parse(event.data);
+
+        if (message.responseId === responseId) {
+          if (isErrorResponse(message)) {
+            let messages = message.errors.map(error => error.message);
+            throw new Error(messages.join("\n"));;
+          }
+          if (isDataResponse(message)) {
+            return message.data;
+          } else {
+            console.warn('unknown response format: ', event.data);
+          }
+        }
+      }
+    }
+
+    return yield handle(next);
+  }
 }
+
+interface HandleResponse {
+  (next: () => Operation): Operation;
+}
+
+interface Query {
+  query: string;
+  live?: boolean;
+}
+
+const parent: Operation = ({ resume, context: { parent }}) => resume(parent.parent);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,89 @@
+import { w3cwebsocket as WebSocket } from 'websocket';
+import { EventEmitter } from 'events';
+import { monitor, Operation } from 'effection';
+import { on } from './effection/events'
+
+import { Message, isErrorResponse, isDataResponse } from './protocol';
+
+const parent: Operation = ({ resume, context: { parent }}) => resume(parent);
+
+export class Client {
+  query: (source: string) => Operation;
+  subscribe: (source: string, forEach: (result: unknown) => Operation) => Operation;
+
+  static *create(url: string): Operation {
+    let { parent: context } = yield parent;
+
+    let client = new Client();
+    let subscriptions = new EventEmitter();
+    let socket = new WebSocket(url);
+    let responseIds = 0;
+
+    socket.onopen = () => subscriptions.emit('open');
+    socket.onclose = event => subscriptions.emit('close', event);
+    socket.onmessage = event => subscriptions.emit('message', event);
+    socket.onerror = event => subscriptions.emit('error', event);
+
+    context.ensure(() => {
+      socket.onopen = socket.onclose = socket.onmessage = socket.onerror = null;
+      socket.close();
+    });
+
+    context.spawn(monitor(function* () {
+      let [error]: [Error] = yield on(subscriptions, 'error');
+      throw error;
+    }));
+
+    context.spawn(monitor(function* () {
+      yield on(subscriptions, 'close');
+      throw new Error('Socket closed on the remote end');
+    }));
+
+    function* send<Command>(command: Command, handle: (next: () => Operation) => Operation) {
+      let responseId = `${responseIds++}`; //we'd want a UUID to avoid hijacking?
+      let request: Message = {...command, responseId};
+
+      socket.send(JSON.stringify(request));
+
+      let next = function* getNextResponse() {
+        while (true) {
+          let [event]: [MessageEvent] = yield on(subscriptions, 'message');
+          let message: Message = JSON.parse(event.data);
+
+          if (message.responseId === responseId) {
+            if (isErrorResponse(message)) {
+              let messages = message.errors.map(error => error.message);
+              throw new Error(messages.join("\n"));;
+            }
+            if (isDataResponse(message)) {
+              return message.data;
+            } else {
+              console.warn('unknown response format: ', event.data);
+            }
+          }
+        }
+      }
+
+      return yield handle(next);
+    }
+
+    client.query = function query(source: string): Operation {
+      return send({ query: source }, function*(next) {
+        return yield next();
+      });
+    }
+
+    client.subscribe = function subscribe(source, forEach): Operation {
+      return send({ query: source, live: true }, function*(next) {
+        while (true) {
+          let response = yield next();
+          yield forEach(response);
+        }
+      })
+    }
+
+    yield on(subscriptions, 'open');
+
+    return client;
+  }
+}

--- a/src/command-server.ts
+++ b/src/command-server.ts
@@ -3,9 +3,12 @@ import { on } from '@effection/events';
 import * as express from 'express';
 import * as graphqlHTTP from 'express-graphql';
 
+import { listenWS } from './ws';
 import { schema } from './schema';
 import { atom, OrchestratorState } from './orchestrator/state';
 import { Test, SerializableTest } from './test';
+
+import { handleMessage } from './command-server/websocket';
 
 interface CommandServerOptions {
   port: number;
@@ -25,7 +28,7 @@ export function* createCommandServer(orchestrator: Context, options: CommandServ
 
     yield send({ ready: "command" }, orchestrator);
 
-    yield
+    yield listenWS(server, handleMessage);
   } finally {
     server.close();
   }

--- a/src/command-server/websocket.ts
+++ b/src/command-server/websocket.ts
@@ -1,12 +1,10 @@
 import { Operation, fork, receive } from 'effection';
 import { watch } from '@effection/events';
 
-import { graphql as executeGraphql } from 'graphql';
-
-import { schema } from '../schema';
 import { atom, OrchestratorState } from '../orchestrator/state';
-
 import { Connection, sendData } from '../ws';
+
+import { graphql } from '../command-server';
 
 interface Message {
   responseId?: string;
@@ -43,7 +41,6 @@ export function* handleMessage(connection: Connection): Operation {
   }
 }
 
-
 function* handleQuery(message: QueryMessage, connection: Connection): Operation {
   yield publishQueryResult(message, yield atom.get(), connection);
 
@@ -68,16 +65,4 @@ function* subscribe(message: QueryMessage, connection: Connection) {
 
 function* handleMutation(message: MutationMessage, connection: Connection): Operation {
   console.log(message, connection);
-}
-
-export function graphql(source: string, state: OrchestratorState): Operation {
-  return executeGraphql({
-    schema,
-    source,
-    rootValue: {
-      echo: ({text}) => text,
-      agents: () => Object.values(state.agents),
-      manifest: () => state.manifest
-    }
-  });
 }

--- a/src/command-server/websocket.ts
+++ b/src/command-server/websocket.ts
@@ -1,0 +1,83 @@
+import { Operation, fork, receive } from 'effection';
+import { watch } from '@effection/events';
+
+import { graphql as executeGraphql } from 'graphql';
+
+import { schema } from '../schema';
+import { atom, OrchestratorState } from '../orchestrator/state';
+
+import { Connection, sendData } from '../ws';
+
+interface Message {
+  responseId?: string;
+}
+
+interface QueryMessage extends Message {
+  query: string;
+  live?: boolean;
+}
+
+interface MutationMessage extends Message {
+  mutation: string;
+}
+
+function isQuery(message: Message): message is QueryMessage {
+  return !!message['query'];
+}
+
+function isMutation(message: Message): message is MutationMessage {
+  return !!message['mutation'];
+}
+
+export function* handleMessage(connection: Connection): Operation {
+  yield watch(connection, "message", message => JSON.parse(message.utf8Data));
+
+  while (true) {
+    let message: Message = yield receive();
+    if (isQuery(message)) {
+      yield fork(handleQuery(message, connection));
+    }
+    if (isMutation(message)) {
+      yield fork(handleMutation(message, connection));
+    }
+  }
+}
+
+
+function* handleQuery(message: QueryMessage, connection: Connection): Operation {
+  yield publishQueryResult(message, yield atom.get(), connection);
+
+  if (message.live) {
+    yield fork(subscribe(message, connection));
+  }
+}
+
+function* publishQueryResult(message: QueryMessage, state: OrchestratorState, connection: Connection): Operation {
+  let result = yield graphql(message.query, state);
+  result.responseId = message.responseId;
+  yield sendData(connection, JSON.stringify(result));
+}
+
+function* subscribe(message: QueryMessage, connection: Connection) {
+  while (true) {
+    let state: OrchestratorState = yield atom.next();
+
+    yield publishQueryResult(message, state, connection);
+  }
+}
+
+function* handleMutation(message: MutationMessage, connection: Connection): Operation {
+  console.log(message, connection);
+}
+
+export function graphql(source: string, state: OrchestratorState): Operation {
+  return executeGraphql({
+    schema,
+    source,
+    rootValue: {
+      echo: ({text}) => text,
+      agents: () => Object.values(state.agents),
+      manifest: () => state.manifest
+    }
+  });
+}

--- a/src/command-server/websocket.ts
+++ b/src/command-server/websocket.ts
@@ -1,31 +1,12 @@
 import { Operation, fork, receive } from 'effection';
 import { watch } from '@effection/events';
 
+import { Message, QueryMessage, MutationMessage, isQuery, isMutation } from '../protocol';
+
 import { atom, OrchestratorState } from '../orchestrator/state';
 import { Connection, sendData } from '../ws';
 
 import { graphql } from '../command-server';
-
-interface Message {
-  responseId?: string;
-}
-
-interface QueryMessage extends Message {
-  query: string;
-  live?: boolean;
-}
-
-interface MutationMessage extends Message {
-  mutation: string;
-}
-
-function isQuery(message: Message): message is QueryMessage {
-  return !!message['query'];
-}
-
-function isMutation(message: Message): message is MutationMessage {
-  return !!message['mutation'];
-}
 
 export function* handleMessage(connection: Connection): Operation {
   yield watch(connection, "message", message => JSON.parse(message.utf8Data));

--- a/src/effection/node.ts
+++ b/src/effection/node.ts
@@ -2,13 +2,11 @@ import { main as effectionMain, Context, Operation } from 'effection';
 
 export function main(operation: Operation): Context {
   return effectionMain(({ context: mainContext, spawn }) => {
-
     spawn(function* main() {
       let interrupt = () => { mainContext.halt(); };
       try {
         process.on('SIGINT', interrupt);
-        yield operation;
-        mainContext.halt();
+        return yield operation;
       } catch(e) {
         console.error(e);
         process.exit(-1);

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -104,6 +104,8 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
 
   if(options.delegate) {
     yield send({ ready: "orchestrator" }, options.delegate);
+  } else {
+    yield send({ ready: "orchestrator" });
   }
 
   try {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,0 +1,36 @@
+export interface Message {
+  responseId?: string;
+}
+
+export interface QueryMessage extends Message {
+  query: string;
+  live?: boolean;
+}
+
+export interface MutationMessage extends Message {
+  mutation: string;
+}
+
+export interface DataResponse extends Message {
+  data: unknown;
+}
+
+export interface ErrorResponse extends Message {
+  errors: Array<{ message: string }>;
+}
+
+export function isQuery(message: Message): message is QueryMessage {
+  return !!message['query'];
+}
+
+export function isMutation(message: Message): message is MutationMessage {
+  return !!message['mutation'];
+}
+
+export function isDataResponse(message: Message): message is DataResponse {
+  return !!message['data'];
+}
+
+export function isErrorResponse(message: Message): message is ErrorResponse {
+  return !!message['errors'];
+}

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -41,7 +41,13 @@ export function* listenWS(server: Server, handler: ConnectionHandler): Operation
 
       let handle = yield fork(function* setupConnection() {
         let halt = () => handle.halt();
-        let fail = (error: Error) => handle.fail(error);
+        let fail = (error: Error) => {
+          if(error["code"] === 'ECONNRESET') {
+            handle.halt();
+          } else {
+            handle.fail(error);
+          }
+        }
         connection.on("error", fail);
         connection.on("close", halt);
         try {

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -22,6 +22,14 @@ export function* createSocketServer(port: number, handler: ConnectionHandler, re
 
   yield ready(server);
 
+  try {
+    yield listenWS(server, handler);
+  } finally {
+    server.close();
+  }
+}
+
+export function* listenWS(server: Server, handler: ConnectionHandler): Operation {
   let socket = new WebSocketServer({
     httpServer: server
   });
@@ -47,7 +55,7 @@ export function* createSocketServer(port: number, handler: ConnectionHandler, re
 
     }
   } finally {
-    server.close();
+    socket.unmount();
   }
 }
 

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -41,7 +41,7 @@ export function* listenWS(server: Server, handler: ConnectionHandler): Operation
 
       let handle = yield fork(function* setupConnection() {
         let halt = () => handle.halt();
-        let fail = (error: Error) => handle.throw(error);
+        let fail = (error: Error) => handle.fail(error);
         connection.on("error", fail);
         connection.on("close", halt);
         try {


### PR DESCRIPTION
Closes #58, depends on #72 

In order to create reactive UIs whether they are dashboards, CLIs, or even UI running inside the agent, there is the need to receive updates about the state of the server. With our current method of querying the server, it is necessary to fetch the query every time over HTTP that you're interested in the state. However, what we'd really like is for state changes to be sent whenever they are necessary, which can only be known by the server.

This adds a websocket server to the current command server that can send and receive messages in order to issue commands or execute queries via graphql.

The message interface is so:

```ts
interface Message {
  responseId?: string;
}

interface QueryMessage extends Message {
  query: string;
  live?: boolean;
}

interface MutationMessage extends Message {
  mutation: string;
}
```

where the `responseId` is a purely client generated value that will be sent back transparently with each response so that the client can reconcile itself.

If the `live` property is passed to a query message, then it will not only run the query and return its result, but it will also listen for state changes and publish that new result to the websocket with the original `responseId`.

However, unless you're writing a client in a language other than JavaScript, you'll never need to know about `responseId` at all since you can use the bigtest client. This PR also includes a client API that will eventually be extracted out into `@bigtest/client` that connects to the web socket command server and lets you issue queries and subscriptions. Here's an example.

```ts
import { Client } from './src/client';

function* runQuery(source: string) {
   // this allocates the client and connects the socket
   // returning only once the socket is connected and open
   // The underlying socket will be closed once this context is exited.
   // any errors in the socket will cause this context to fail.
   let client: Client = yield Client.create('ws://localhost:24002');

   // do a one shot query.
   let { data } = yield client.query('{ agents { browser { name } } }');

   // subscribe to a query by passing an operation run for each published result
  yield client.subscribe('{ manifest { path } }', function*(data) {
    console.log('manifest updated', data);
  });
}
```

I was going to hold off on writing a client, but it turned out to be necessary to write the tests.

Finally, I added two little scripts `bin/query.ts` and `bin/subscribe.ts` to be little utilities to run commands against the server:

query state:
```
$ yarn ts-node ./bin/query.ts "{ agents { browser { name } } }"
{
  "agents": [
    {
      "browser": {
        "name": "Safari"
      }
    }
  ]
}
```

Or subscribe to a query

```
$ yarn ts-node ./bin/subscribe.ts "{ agents { browser { name } } }"
==== new subscription result ====
{
  "agents": [
    {
      "browser": {
        "name": "Safari"
      }
    }
  ]
}
==== new subscription result ====
{
  "agents": [
    {
      "browser": {
        "name": "Safari"
      }
    },
    {
      "browser": {
        "name": "Chrome"
      }
    }
  ]
}
==== new subscription result ====
{
  "agents": [
    {
      "browser": {
        "name": "Safari"
      }
    },
    {
      "browser": {
        "name": "Chrome"
      }
    },
    {
      "browser": {
        "name": "Firefox"
      }
    }
  ]
}
```

### TODOS and Open Questions

- [x] add test cases