### PR TITLE
Refactor State object into a reactive atom

### DIFF
--- a/src/connection-server.ts
+++ b/src/connection-server.ts
@@ -2,12 +2,11 @@ import { Context, Operation, fork, send, receive, any, timeout } from 'effection
 import { watch } from '@effection/events';
 
 import { createSocketServer, Connection, sendData } from './ws';
-import { State } from './orchestrator/state';
+import { atom } from './orchestrator/state';
 
 import { lensPath, assoc, dissoc } from 'ramda';
 
 interface ConnectionServerOptions {
-  state: State;
   port: number;
   proxyPort: number;
   testFilePort: number;
@@ -44,14 +43,14 @@ export function* createConnectionServer(orchestrator: Context, options: Connecti
 
     try {
       console.debug('[connection] received connection message', data);
-      options.state.over(agentsLens, assoc(identifier, assoc("identifier", identifier, data)));
+      yield atom.over(agentsLens, assoc(identifier, assoc("identifier", identifier, data)));
 
       while (true) {
         let message = yield receive({ message: any });
         console.debug("[connection] got message", message);
       }
     } finally {
-      options.state.over(agentsLens, dissoc(identifier));
+      yield atom.over(agentsLens, dissoc(identifier));
       console.debug('[connection] disconnected');
     }
   }

--- a/src/orchestrator/state.ts
+++ b/src/orchestrator/state.ts
@@ -1,5 +1,10 @@
+import { EventEmitter } from 'events';
+import { Operation, Context } from 'effection';
+import { on } from '@effection/events';
+
+import * as R from 'ramda';
+
 import { Test } from '../test';
-import { view, set, over } from 'ramda';
 
 export type AgentState = {
   identifier: string;
@@ -32,29 +37,69 @@ export type OrchestratorState = {
   manifest: ManifestEntry[];
 }
 
-export class State {
-  state: OrchestratorState = {
-    agents: {},
-    manifest: [],
-  }
+class Atom {
+  allocate: () => Operation;
+  update: (value) => Operation;
+  view: (lens) => Operation;
+  over: (lens, fn) => Operation;
+  get: () => Operation;
+  set: (lens, value) => Operation;
+  next: () => Operation;
 
-  get(): OrchestratorState {
-    return this.state;
-  }
+  constructor() {
+    //eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let id: string = Symbol('Atom<State>') as any;
+    let subscriptions = new EventEmitter();
 
-  update(fn: (OrchestratorState) => OrchestratorState): void {
-    this.state = fn(this.state);
-  }
+    let parent: Operation = ({ resume, context: { parent }}) => resume(parent.parent);
 
-  view(lens) {
-    return view(lens, this.get());
-  }
+    function* find(key: string): Operation {
+      for (let current: Context = yield parent; current; current = current.parent) {
+        if (current[key]) {
+          return current;
+        }
+      }
+      throw new Error('Atom not found. It must be allocated on the tree with the atom.allocate() operation');
+    }
 
-  set(lens, value) {
-    this.update((state) => set(lens, value, state) as unknown as OrchestratorState);
-  }
+    function* get(key: string) {
+      let context = yield find(key);
+      return context[key];
+    }
 
-  over(lens, fn) {
-    this.update((state) => over(lens, fn, state) as unknown as OrchestratorState);
+    function* set<T>(key: string, value: T) {
+      let context = yield find(key);
+      context[key] = value;
+      subscriptions.emit('state', value);
+      return value;
+    }
+
+    this.allocate = function* allocate(): Operation {
+      let context = yield parent;
+      context[id] = { agents: {} }
+      return get(id);
+    };
+
+    this.view = function* view(lens): Operation {
+      let current = yield get(id);
+      return R.view(lens, current);
+    }
+
+    this.over = function* over(lens, fn) {
+      let current = yield get(id);
+      let next = R.over(lens, fn, current);
+      return yield set(id, next);
+    }
+
+    this.get = () => this.view(R.lensPath([]));
+    this.set = (lens, value) => this.over(lens, () => value);
+    this.update = (value) => this.over(R.lensPath([]), value);
+
+    this.next = function* next() {
+      let [state]: [OrchestratorState] = yield on(subscriptions, 'state');
+      return state;
+    }
   }
 }
+
+export const atom = new Atom();

--- a/test/command-server.test.ts
+++ b/test/command-server.test.ts
@@ -18,11 +18,9 @@ describe('command server', () => {
   beforeEach(async () => {
     orchestrator = actions.fork(function*() { yield });
 
-    actions.fork(function* top() {
-      yield createCommandServer(orchestrator, {
-        port: COMMAND_PORT,
-      })
-    });
+    actions.fork(createCommandServer(orchestrator, {
+      port: COMMAND_PORT,
+    }));
 
     await actions.receive(orchestrator, { ready: "command" });
   });

--- a/test/helpers/world.ts
+++ b/test/helpers/world.ts
@@ -1,13 +1,17 @@
 import { main, Context, Operation } from 'effection';
 import fetch, { Response } from 'node-fetch';
 import { AbortController } from 'abort-controller';
+import { atom } from '../../src/orchestrator/state';
 
 type RequestMethod = 'post' | 'get';
 
 export class World {
   execution: any;
   constructor() {
-    this.execution = main(function*() { yield; });
+    this.execution = main(function*() {
+      yield atom.allocate();
+      yield;
+    });
   }
 
   destroy() {

--- a/test/test-file-server.test.ts
+++ b/test/test-file-server.test.ts
@@ -8,7 +8,7 @@ import { Context } from 'effection';
 
 import { actions } from './helpers';
 import { createTestFileServer } from '../src/test-file-server';
-import { State } from '../src/orchestrator/state';
+import { atom, OrchestratorState } from '../src/orchestrator/state';
 
 const TEST_DIR = "./tmp/test-file-server"
 const MANIFEST_PATH = "./tmp/test-file-server/manifest.js"
@@ -19,7 +19,6 @@ let TEST_FILE_PORT = 24200;
 
 describe('test file server', () => {
   let orchestrator: Context;
-  let state: State;
 
   beforeEach((done) => rmrf(TEST_DIR, done));
   beforeEach(async () => {
@@ -27,13 +26,13 @@ describe('test file server', () => {
     await writeFile(MANIFEST_PATH, "module.exports = [{ path: 'someworld', test: 123 }];");
 
     orchestrator = actions.fork(function*() { yield });
-    state = new State();
 
-    actions.fork(createTestFileServer(orchestrator, {
-      manifestPath: MANIFEST_PATH,
-      port: TEST_FILE_PORT,
-      state
-    }));
+    actions.fork(function*() {
+      yield createTestFileServer(orchestrator, {
+        manifestPath: MANIFEST_PATH,
+        port: TEST_FILE_PORT
+      });
+    });
 
     await actions.receive(orchestrator, { ready: "test-files" });
   });
@@ -56,19 +55,27 @@ describe('test file server', () => {
   });
 
   describe('reading manifest from state on start', () => {
+    let state: OrchestratorState;
+    beforeEach(async () => {
+      state = await actions.fork(atom.get());
+    });
+
     it('returns the manifest from the state', () => {
-      expect(state.get().manifest[0]).toEqual({ path: 'someworld', test: 123 });
+      let { manifest: [ first ] } = state;
+      expect(first).toEqual({ path: 'someworld', test: 123 });
     });
   });
 
   describe('updating the manifest and then reading it', () => {
+    let state: OrchestratorState;
     beforeEach(async () => {
       await writeFile(MANIFEST_PATH, "module.exports = [{ path: 'boo', test: 432 }];");
       await actions.receive(orchestrator, { update: "test-files" });
+      state = await actions.fork(atom.get());
     });
 
     it('returns the updated manifest from the state', () => {
-      expect(state.get().manifest[0]).toEqual({ path: 'boo', test: 432 });
+      expect(state.manifest[0]).toEqual({ path: 'boo', test: 432 });
     });
   });
 });


### PR DESCRIPTION
In order to make reactivity of the bigtest server state a snap, we need a way to receive notifications about state changes.

This refactors the current state application into a "reactive atom" that is accessed via operations instead of synchronous methods. I tried this approach because it's definitely anticipated that we are going to be reacting to this atom at a bunch of different points throughout the orchestrator tree, and part of those reactions is that you will need to execute operations within a specific effection context in order for code not to "leak" into an unsafe space where it could block forever or throw an exception that isn't handled. 

We could just make the `state` object an event emitter, but then, in order to use it to handle an event from anywhere, you have to keep a reference to the context where you plan on using it, so that you can "re-enter" it by spawning the event handler at that point in the tree. That's got some complexity because now in order to be technically safe, you need to make sure and validate the context is still running before dispatching the event to the handler.

The other problem with a synchronous style callback like an EventEmitter, is that if _any_ of the event listeners throw an exception, then that will percolate inside the _emitting_ stack, and **not** the _handling_ stack. This almost certainly never what you want.

By making the `atom` "operation native" it can be seamlessly composed into any other operation, either with the generator API, but also using the simple function API. It's easy to imagine adding some handy operations to atom.

```ts
yield atom.forEach(function*(state) {
  console.log(`new state`, state);
});
```

```ts
yield atom.whenever(state => state.agents.length > 10, function*() {
  console.log('did you mean to connect more than 10 agents?');
});
```

Or if we ended up adding some more functional composition things that worked over all `Operations`

```ts
function map(operation: Operation<A>, fn: a => b): Operation<B> {
  return fn(yield operation);
}

function* useAgents() {
  let agentArray = yield map(agent.next(), state => Object.values(state.agents));
}
```