### PR TITLE
Load tests in raw manifest format

### DIFF
--- a/src/orchestrator/state.ts
+++ b/src/orchestrator/state.ts
@@ -1,3 +1,4 @@
+import { Test } from '../test';
 import { view, set, over } from 'ramda';
 
 export type AgentState = {
@@ -23,7 +24,7 @@ export type AgentState = {
 
 export type ManifestEntry = {
   path: string;
-  test: any;
+  test: Test;
 }
 
 export type OrchestratorState = {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -3,8 +3,8 @@ import { buildSchema } from 'graphql';
 export const schema =  buildSchema(`
 type Query {
   echo(text: String!): String
-  agents: [Agent]
-  manifest: [ManifestEntry]
+  agents: [Agent!]!
+  manifest: [ManifestEntry!]!
 }
 
 type Agent {
@@ -38,5 +38,8 @@ type Engine {
 
 type ManifestEntry {
   path: String!
+  test: Test!
 }
+
+scalar Test
 `);

--- a/src/test-file-watcher.ts
+++ b/src/test-file-watcher.ts
@@ -20,7 +20,7 @@ function* writeManifest(options: TestFileWatcherOptions) {
 
   for(let file of files) {
     let filePath = "./" + path.relative(path.dirname(options.manifestPath), file);
-    manifest += `  { path: ${JSON.stringify(file)}, test: require(${JSON.stringify(filePath)}) },\n`;
+    manifest += `  { path: ${JSON.stringify(file)}, test: require(${JSON.stringify(filePath)}).default },\n`;
   }
 
   manifest += "];\n";

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,35 @@
+export interface Test {
+  description: string;
+  steps: Iterable<Step>;
+  assertions: Iterable<Assertion>;
+  children: Iterable<Test>;
+}
+
+export interface Step {
+  description: string;
+  action: Action;
+}
+
+export interface Assertion {
+  description: string;
+  check: Check;
+}
+
+export interface Action {
+  (context: Context): Promise<Context | void>;
+}
+
+export interface Check {
+  (context: Context): void;
+}
+
+export type Context = Record<string, unknown>;
+
+export interface SerializableTest {
+  description: string;
+  steps: Array<{ description: string }>;
+  assertions: Array<{ description: string }>;
+  children: Array<SerializableTest>;
+}
+
+export type Manifest = Iterable<{ path: string; test: SerializableTest }>;

--- a/test/fixtures/empty.t.ts
+++ b/test/fixtures/empty.t.ts
@@ -1,0 +1,6 @@
+export default {
+  description: "An empty test with no steps and no children",
+  steps: [],
+  assertions: [],
+  children: []
+}

--- a/test/fixtures/example.t.ts
+++ b/test/fixtures/example.t.ts
@@ -1,3 +1,0 @@
-export default {
-  "hello": "hellofromexample"
-}

--- a/test/fixtures/monkey.t.ts
+++ b/test/fixtures/monkey.t.ts
@@ -1,3 +1,0 @@
-export default {
-  "hello": "monkey"
-}

--- a/test/fixtures/raw-tree-format.t.ts
+++ b/test/fixtures/raw-tree-format.t.ts
@@ -1,0 +1,51 @@
+import { Context } from '../../src/test';
+
+export default {
+  description: "Signing In",
+  steps: [
+    {
+      description: "given a user",
+      action: async (context: Context) => ({ ...context, user: { username: "cowboyd" } })
+    },
+    {
+      description: "when I fill in the login form",
+      action: async () => {}
+    },
+    {
+      description: "when I press the submit button",
+      action: async () => {}
+    }
+  ],
+  assertions: [
+    {
+      description: "then I am logged in",
+      check: () => true
+    },
+    {
+      description: "then I am on the homepage",
+      check: () => true
+    }
+  ],
+  children: [
+    {
+      description: "when I log out",
+      steps: [
+        {
+          description: "when I click on the logout button",
+          action: async () => {}
+        }
+      ],
+      assertions: [
+        {
+          description: "it takes me back to the homepage",
+          check: () => {}
+        },
+        {
+          description: "My username is no longer in the top bar",
+          check: () => {}
+        }
+      ],
+      children: []
+    }
+  ]
+}

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -114,7 +114,7 @@ describe('orchestrator', () => {
     });
 
     it('serves the application', () => {
-      expect(body).toContain('hellofromexample');
+      expect(body).toContain('Signing In');
     });
   });
 });

--- a/test/test-file-watcher.test.ts
+++ b/test/test-file-watcher.test.ts
@@ -25,8 +25,8 @@ describe('test-file-watcher', () => {
   beforeEach((done) => rmrf(TEST_DIR, done));
   beforeEach(async () => {
     await mkdir(TEST_DIR, { recursive: true });
-    await writeFile(TEST_DIR + "/test1.t.js", "module.exports = { hello: 'world' };");
-    await writeFile(TEST_DIR + "/test2.t.js", "module.exports = { monkey: 'foo' };");
+    await writeFile(TEST_DIR + "/test1.t.js", "module.exports = { default: { hello: 'world' }};");
+    await writeFile(TEST_DIR + "/test2.t.js", "module.exports = { default: { monkey: 'foo' }};");
 
     orchestrator = actions.fork(function*() { yield });
 
@@ -60,7 +60,7 @@ describe('test-file-watcher', () => {
     let manifest;
 
     beforeEach(async () => {
-      await writeFile(TEST_DIR + "/test3.t.js", "module.exports = { third: 'test' };");
+      await writeFile(TEST_DIR + "/test3.t.js", "module.exports = { default: { third: 'test' } };");
       await actions.receive(orchestrator, { change: "manifest" });
       manifest = await loadManifest();
     });


### PR DESCRIPTION
There are many potential DSLs for defining our tests, however, they will all resolve into a single format that can be understood by the runtime: one that contains a strict tree of actions and assertions.

This is a first stab at that format. It contains a recursive Test structure that is defined with both with TypeScript interfaces, but also with GraphQL IDL. Note that the GraphQL schema does not contain any non-serialiazable objects, specifically the lambdas of the actions and checks which cannot be sent across the wire.

Follow on work from this:

- [ ] validating test objects that are imported from the manifest
  - make sure there is a default export (or maybe a robust algorithm for finding the test export)
  - validating the format to make sure that there are no tests with the same id ().
- [ ] define a DSL function to emit this format.
- [ ] create a manifest parser that constructs the test state from JSON