### PR TITLE
🐛Remove event handler in teardown hook

### DIFF
--- a/src/effection/events.ts
+++ b/src/effection/events.ts
@@ -8,10 +8,10 @@ type EventName = string | symbol;
  * operation which resumes when the event occurrs.
  */
 export function on(emitter: EventEmitter, eventName: EventName): Operation {
-  return (control) => {
-    let resume = (...args: unknown[]) => control.resume(args);
-    emitter.on(eventName, resume);
-    return () => emitter.off(eventName, resume);
+  return ({ resume, ensure }) => {
+    let handle = (...args: unknown[]) => resume(args);
+    emitter.on(eventName, handle);
+    ensure(() => emitter.off(eventName, handle));
   }
 }
 


### PR DESCRIPTION
In order versions of effection, the teardown hook was added by returning a function from the controller. The newest version however, requires explicitly invoking the `ensure` function in order to register the hook. We didn't update to the new method, and so our event handlers were never getting un-registered.

This wasn't effecting us because the `resume`() of a halted context is a no-op, but it was leaking the context itself which is not good.