### PR TITLE
Replace implicit mailbox with explicit mailbox

### DIFF
--- a/bin/start.ts
+++ b/bin/start.ts
@@ -1,12 +1,15 @@
-import { fork, receive } from 'effection';
+import { fork } from 'effection';
 import { main } from '@effection/node';
 import * as tempy from 'tempy';
 
 import { createOrchestrator } from '../src/index';
+import { Mailbox } from '@effection/events';
 
 main(function*() {
-  let orchestrator = yield fork(createOrchestrator({
-    delegate: this,
+  let mailbox = new Mailbox();
+
+  yield fork(createOrchestrator({
+    delegate: mailbox,
     appCommand: "yarn",
     appArgs: ["test:app:start"],
     appEnv: {
@@ -23,7 +26,7 @@ main(function*() {
     testManifestPath: tempy.file({ name: 'manifest.js' }),
   }));
 
-  yield receive({ ready: "orchestrator" }, orchestrator);
+  yield mailbox.receive({ ready: "orchestrator" });
 
   console.log("[cli] orchestrator ready!");
 

--- a/src/agent-server.ts
+++ b/src/agent-server.ts
@@ -1,12 +1,12 @@
-import { send, Operation, Context } from 'effection';
-import { on } from '@effection/events';
+import { Operation } from 'effection';
+import { on, Mailbox } from '@effection/events';
 import { ChildProcess, fork as forkProcess } from '@effection/child_process';
 
 interface AgentServerOptions {
   port: number;
 };
 
-export function* createAgentServer(orchestrator: Context, options: AgentServerOptions): Operation {
+export function* createAgentServer(mail: Mailbox, options: AgentServerOptions): Operation {
   // TODO: @precompile we want this to use a precompiled agent server when used as a package
   let child: ChildProcess = yield forkProcess(
     './bin/parcel-server.ts',
@@ -23,7 +23,7 @@ export function* createAgentServer(orchestrator: Context, options: AgentServerOp
     [message] = yield on(child, "message");
   } while(message.type !== "ready");
 
-  yield send({ ready: "agent" }, orchestrator);
+  yield mail.send({ ready: "agent" });
 
   yield on(child, "exit");
 }

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -1,5 +1,5 @@
-import { send, fork, timeout, Operation, Context } from 'effection';
-import { on } from '@effection/events';
+import { fork, timeout, Operation } from 'effection';
+import { on, Mailbox } from '@effection/events';
 import { spawn } from '@effection/child_process';
 import { Socket } from 'net';
 import * as process from 'process';
@@ -34,7 +34,7 @@ function isReachable(port: number, options: { timeout: number } = { timeout: 100
   }
 };
 
-export function* createAppServer(orchestrator: Context, options: AppServerOptions): Operation {
+export function* createAppServer(mail: Mailbox, options: AppServerOptions): Operation {
   let child = yield spawn(options.command, options.args || [], {
     cwd: options.dir,
     detached: true,
@@ -50,7 +50,7 @@ export function* createAppServer(orchestrator: Context, options: AppServerOption
     yield timeout(100);
   }
 
-  yield send({ ready: "app" }, orchestrator);
+  yield mail.send({ ready: "app" });
 
   yield on(child, "exit");
 

--- a/src/command-server.ts
+++ b/src/command-server.ts
@@ -1,5 +1,5 @@
-import { Operation, Context, fork, send } from 'effection';
-import { on } from '@effection/events';
+import { Operation, fork } from 'effection';
+import { on, Mailbox } from '@effection/events';
 import * as express from 'express';
 import * as graphqlHTTP from 'express-graphql';
 import { graphql as executeGraphql } from 'graphql';
@@ -17,7 +17,7 @@ interface CommandServerOptions {
   port: number;
 };
 
-export function* createCommandServer(orchestrator: Context, options: CommandServerOptions): Operation {
+export function* createCommandServer(mail: Mailbox, options: CommandServerOptions): Operation {
   let app = yield createApp(options.atom);
   let server = app.listen(options.port);
 
@@ -29,7 +29,7 @@ export function* createCommandServer(orchestrator: Context, options: CommandServ
   try {
     yield on(server, 'listening');
 
-    yield send({ ready: "command" }, orchestrator);
+    yield mail.send({ ready: "command" });
 
     yield listenWS(server, handleMessage(options.atom));
   } finally {

--- a/src/effection/events/mailbox.ts
+++ b/src/effection/events/mailbox.ts
@@ -1,0 +1,46 @@
+import { fork, monitor, Operation } from 'effection';
+import { EventEmitter } from 'events';
+
+import { on, onEach, EventName } from '../events';
+import { compile } from './pattern';
+export { any } from './pattern';
+
+export class Mailbox {
+  private subscriptions = new EventEmitter();
+  private messages = new Set();
+
+  *send(message: unknown): Operation {
+    this.messages.add(message);
+    this.subscriptions.emit('message');
+  }
+
+  *receive(pattern: unknown = undefined): Operation {
+    let match = compile(pattern);
+    let { messages, subscriptions } = this;
+    while (true) {
+      for (let message of messages) {
+        if (match(message)) {
+          messages.delete(message);
+          return message;
+        }
+      }
+      yield on(subscriptions, 'message');
+    }
+  }
+
+  static *watch(
+    emitter: EventEmitter,
+    events: EventName | EventName[],
+    prepare: (event: { event: string; args: unknown[] }) => unknown = x => x
+  ): Operation {
+    let mailbox = new Mailbox();
+    let parent = yield ({ resume, context: { parent }}) => resume(parent.parent);
+
+    parent.spawn(monitor(function* () {
+      for (let name of [].concat(events)) {
+        yield fork(onEach(emitter, name, (...args) => mailbox.send(prepare({ event: name, args }))));
+      }
+    }));
+    return mailbox;
+  }
+}

--- a/src/effection/events/pattern.ts
+++ b/src/effection/events/pattern.ts
@@ -1,0 +1,31 @@
+export function compile(pattern: unknown): (target: unknown) => boolean {
+  return function matcher(target: unknown): boolean {
+    if(pattern === undefined) {
+      return true;
+    } else if(Array.isArray(pattern)) {
+      return pattern.every((value, index) => compile(value)(target[index]));
+    } else if(typeof(pattern) === "object") {
+      return Object.entries(pattern).every(([key, value]) => compile(value)(target[key]));
+    } else if(typeof(pattern) === "function") {
+      return pattern(target);
+    } else {
+      return pattern === target;
+    }
+  };
+}
+
+export function any(type: unknown) {
+  if(type === "array") {
+    return function anyMatcher(value: unknown) {
+      return Array.isArray(value);
+    };
+  } else if(type) {
+    return function anyMatcher(value: unknown) {
+      return typeof(value) === type;
+    };
+  } else {
+    return function anyMatcher() {
+      return true;
+    };
+  }
+}

--- a/src/parcel-server.ts
+++ b/src/parcel-server.ts
@@ -1,8 +1,8 @@
-import { Operation, receive } from 'effection';
+import { Operation } from 'effection';
 import * as Bundler from 'parcel-bundler';
 import { ParcelOptions } from 'parcel-bundler';
 import { createServer, RequestListener } from 'http';
-import { watch } from '@effection/events';
+import { Mailbox } from '@effection/events';
 import { EventEmitter } from 'events';
 import { listen } from './http';
 
@@ -13,7 +13,7 @@ interface ParcelServerOptions {
 export function* createParcelServer(entryPoints: string[], options: ParcelServerOptions, parcelOptions?: ParcelOptions): Operation {
   let bundler: ParcelBundler = new Bundler(entryPoints, parcelOptions || {});
 
-  yield watch(bundler, "buildEnd");
+  let events = yield Mailbox.watch(bundler, "buildEnd");
 
   let middleware = bundler.middleware();
   let server = createServer(middleware)
@@ -21,18 +21,17 @@ export function* createParcelServer(entryPoints: string[], options: ParcelServer
   try {
     yield listen(server, options.port);
 
-    yield receive({ event: "buildEnd" });
+    yield events.receive({ event: "buildEnd" });
 
     if (process.send) {
       process.send({ type: "ready", options: bundler.options });
     }
 
     while(true) {
-      yield receive({ event: "buildEnd" });
+      yield events.receive({ event: "buildEnd" });
 
       process.send({ type: "update" });
     }
-    yield;
   } finally {
     bundler.stop();
     server.close();

--- a/test/command-server.test.ts
+++ b/test/command-server.test.ts
@@ -2,6 +2,7 @@ import { describe, beforeEach, it } from 'mocha';
 import * as expect from 'expect';
 
 import { Operation, Context } from 'effection';
+import { Mailbox } from '@effection/events';
 
 import { Client } from '../src/client';
 import { actions } from './helpers';
@@ -14,19 +15,19 @@ import { Test, SerializableTest } from '../src/test';
 let COMMAND_PORT = 24200;
 
 describe('command server', () => {
-  let orchestrator: Context;
+  let mail: Mailbox;
   let atom: Atom;
 
   beforeEach(async () => {
+    mail = new Mailbox();
     atom = new Atom();
-    orchestrator = actions.fork(function*() { yield });
 
-    actions.fork(createCommandServer(orchestrator, {
+    actions.fork(createCommandServer(mail, {
       atom,
       port: COMMAND_PORT,
     }));
 
-    await actions.receive(orchestrator, { ready: "command" });
+    await actions.receive(mail, { ready: "command" });
   });
 
   describe('fetching the agents at the start', () => {

--- a/test/test-file-server.test.ts
+++ b/test/test-file-server.test.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 
 import { Response } from 'node-fetch';
 import { Context } from 'effection';
+import { Mailbox } from '@effection/events';
 
 import { actions } from './helpers';
 import { createTestFileServer } from '../src/test-file-server';
@@ -20,7 +21,7 @@ let TEST_FILE_PORT = 24200;
 
 describe('test file server', () => {
   let atom: Atom;
-  let orchestrator: Context;
+  let orchestrator: Mailbox;
 
   beforeEach((done) => rmrf(TEST_DIR, done));
   beforeEach(async () => {
@@ -28,7 +29,7 @@ describe('test file server', () => {
     await writeFile(MANIFEST_PATH, "module.exports = [{ path: 'someworld', test: 123 }];");
 
     atom = new Atom();
-    orchestrator = actions.fork(function*() { yield });
+    orchestrator = new Mailbox();
 
     actions.fork(function*() {
       yield createTestFileServer(orchestrator, {


### PR DESCRIPTION
The send / receive operations can be confusing because of their implicit / vs explicit nature. When you see a `send` operation or a `receive` operation, You have to track in your head which one is going to a different place, and which one is going to the implicit message queue for a given task.

This can be tricky if your eye doesn't catch a function boundary while scanning the code:

```ts
if (someCondition) {
  // same mailbox as enclosing block.
  yield receive();
}
```

vs

```ts
yield onEach(function*() {
  // different mailbox from enclosing block.
  yield receive();
});
```

Also, for those not familiar with the `watch` API, the implicit semantics can be tricky because it's unclear what "thing" the `watch` operation is changing, and where exactly messages are going to do.

```ts
// what exactly is this doing?
yield watch(connection, "message");
```

It's worth noting that from a purely resource perspective, we're creating a message queue for every single effection operation, most of which go completely unused, which seems like awaste.

As a little weekend project, I made this experiment with extracting the mailbox mechanism from an implicit effection operation to an explicit one that lives inside the `@effection/events` package as a natural "effection-savvy" mechanism for working with events.

The above examples are now unambiguous:

```ts
if (someCondition) {
  // receive message from `mailbox`
  yield mailbox.receive();
}
```

```ts
yield onEach(function*() {
  // receive message from `mailbox`;
  yield mailbox.receive();
});
```

```ts
// `messages`` is now a mailbox that collects "message" events
// from `connection`
let messages = Mailbox.watch(connection, "message");
```

Oddly enough, doing it explicitly this way made the actual implementation much simpler than the implicit version.