### PR TITLE
Make send a synchronous operation

### DIFF
--- a/src/agent-server.ts
+++ b/src/agent-server.ts
@@ -23,7 +23,7 @@ export function* createAgentServer(mail: Mailbox, options: AgentServerOptions): 
     [message] = yield on(child, "message");
   } while(message.type !== "ready");
 
-  yield mail.send({ ready: "agent" });
+  mail.send({ ready: "agent" });
 
   yield on(child, "exit");
 }

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -50,7 +50,7 @@ export function* createAppServer(mail: Mailbox, options: AppServerOptions): Oper
     yield timeout(100);
   }
 
-  yield mail.send({ ready: "app" });
+  mail.send({ ready: "app" });
 
   yield on(child, "exit");
 

--- a/src/command-server.ts
+++ b/src/command-server.ts
@@ -29,7 +29,7 @@ export function* createCommandServer(mail: Mailbox, options: CommandServerOption
   try {
     yield on(server, 'listening');
 
-    yield mail.send({ ready: "command" });
+    mail.send({ ready: "command" });
 
     yield listenWS(server, handleMessage(options.atom));
   } finally {

--- a/src/connection-server.ts
+++ b/src/connection-server.ts
@@ -59,6 +59,6 @@ export function* createConnectionServer(mail: Mailbox, options: ConnectionServer
     }
   }
   yield createSocketServer(options.port, handleConnection, function*() {
-    yield mail.send({ ready: "connection" });
+    mail.send({ ready: "connection" });
   });
 }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -104,7 +104,7 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
   console.log(`[orchestrator] launch agents via: ${agentUrl}`);
   console.log(`[orchestrator] show GraphQL dashboard via: ${commandUrl}`);
 
-  yield mail.send({ ready: "orchestrator" });
+  mail.send({ ready: "orchestrator" });
 
   try {
     while(true) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -86,7 +86,7 @@ export function* createProxyServer(mail: Mailbox, options: ProxyOptions): Operat
   try {
 
     yield listen(server, options.port);
-    yield mail.send({ ready: 'proxy' });
+    mail.send({ ready: 'proxy' });
 
     while(true) {
       let { event, args } = yield events.receive({ event: any("string") });

--- a/src/test-file-server.ts
+++ b/src/test-file-server.ts
@@ -40,7 +40,7 @@ export function* createTestFileServer(mail: Mailbox, options: TestFileServerOpti
   console.debug("[test files] test files initialized");
 
   yield fork(loadManifest(options.atom, outDir));
-  yield mail.send({ ready: "test-files" });
+  mail.send({ ready: "test-files" });
 
   while(true) {
     yield messages.receive({ type: "update" });
@@ -48,6 +48,6 @@ export function* createTestFileServer(mail: Mailbox, options: TestFileServerOpti
     console.debug("[test files] test files updated");
 
     yield fork(loadManifest(options.atom, outDir));
-    yield mail.send({ update: "test-files" });
+    mail.send({ update: "test-files" });
   }
 }

--- a/src/test-file-watcher.ts
+++ b/src/test-file-watcher.ts
@@ -40,13 +40,13 @@ export function* createTestFileWatcher(mail: Mailbox, options: TestFileWatcherOp
     yield events.receive({ event: 'ready' });
     yield writeManifest(options);
 
-    yield mail.send({ ready: "manifest" });
+    mail.send({ ready: "manifest" });
 
     while(true) {
       yield events.receive();
       yield writeManifest(options);
 
-      yield mail.send({ change: "manifest" });
+      mail.send({ change: "manifest" });
     }
   } finally {
     watcher.close();


### PR DESCRIPTION
This has the advantage of being able to send messages from outside effection, and it somewhat mirrors our changes to `Atom`. There isn't really any need for `send` to be an operation, since we don't need to work with any Effection related stuff.