### PR TITLE
Thinner abstraction on top of fetch

### DIFF
--- a/test/command-server.test.ts
+++ b/test/command-server.test.ts
@@ -217,7 +217,7 @@ describe('command server', () => {
 });
 
 async function query(text: string) {
-  let response = await actions.get(`http://localhost:${COMMAND_PORT}?query={${encodeURIComponent(text)}}`);
+  let response = await actions.fetch(`http://localhost:${COMMAND_PORT}?query={${encodeURIComponent(text)}}`);
   return await response.json();
 }
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,4 +1,4 @@
-import { Response } from 'node-fetch';
+import { Response, RequestInfo, RequestInit } from 'node-fetch';
 import { Context, Operation } from 'effection';
 import { World } from './helpers/world';
 
@@ -10,7 +10,7 @@ import { Mailbox } from '../src/effection/events';
 interface Actions {
   fork<T>(operation: Operation): Context;
   receive(mailbox: Mailbox, pattern: any): PromiseLike<any>;
-  get(url: string): PromiseLike<Response>;
+  fetch(resource: RequestInfo, init?: RequestInit): PromiseLike<Response>;
   startOrchestrator(): PromiseLike<Context>;
 }
 
@@ -25,8 +25,9 @@ export const actions: Actions = {
     return actions.fork(mailbox.receive(pattern));
   },
 
-  get(url: string): Promise<Response> {
-    return currentWorld.get(url);
+  fetch(resource: RequestInfo, init?: RequestInit): PromiseLike<Response> {
+    return actions.fork(currentWorld.fetch(resource, init));
+
   },
 
   startOrchestrator() {

--- a/test/helpers/world.ts
+++ b/test/helpers/world.ts
@@ -1,8 +1,6 @@
 import { main, Context, Operation } from 'effection';
-import fetch, { Response } from 'node-fetch';
+import fetch, { Response, RequestInfo, RequestInit } from 'node-fetch';
 import { AbortController } from 'abort-controller';
-
-type RequestMethod = 'post' | 'get';
 
 export class World {
   execution: any;
@@ -18,14 +16,11 @@ export class World {
     return this.execution.spawn(operation);
   }
 
-  get(url: string): Promise<Response>{
-    return this.request('get', url);
-  }
-
-  request(method: RequestMethod, url: string): Promise<Response> {
+  fetch(resource: RequestInfo, init: RequestInit = {}): Promise<Response> {
     let controller = new AbortController();
-    let { signal } = controller;
-    let result = fetch(url, { method, signal });
+    init.signal = controller.signal;
+
+    let result = fetch(resource, init);
 
     this.execution.ensure(() => controller.abort());
 

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -15,7 +15,7 @@ describe('orchestrator', () => {
     let response: Response;
     let body: string;
     beforeEach(async () => {
-      response = await actions.get('http://localhost:24102?query={echo(text:"Hello World")}');
+      response = await actions.fetch('http://localhost:24102?query={echo(text:"Hello World")}');
       body = await response.json();
     });
 
@@ -32,7 +32,7 @@ describe('orchestrator', () => {
     let response: Response;
     let body: string;
     beforeEach(async () => {
-      response = await actions.get('http://localhost:24104/index.html');
+      response = await actions.fetch('http://localhost:24104/index.html');
       body = await response.text();
     });
 
@@ -49,7 +49,7 @@ describe('orchestrator', () => {
     let response: Response;
     let body: string;
     beforeEach(async () => {
-      response = await actions.get('http://localhost:24104/harness.js');
+      response = await actions.fetch('http://localhost:24104/harness.js');
       body = await response.text();
     });
 
@@ -67,7 +67,7 @@ describe('orchestrator', () => {
     let response: Response;
     let body: string;
     beforeEach(async () => {
-      response = await actions.get('http://localhost:24100/');
+      response = await actions.fetch('http://localhost:24100/');
       body = await response.text();
     });
 
@@ -84,7 +84,7 @@ describe('orchestrator', () => {
     let response: Response;
     let body: string;
     beforeEach(async () => {
-      response = await actions.get('http://localhost:24101/');
+      response = await actions.fetch('http://localhost:24101/');
       body = await response.text();
     });
 
@@ -105,7 +105,7 @@ describe('orchestrator', () => {
     let response: Response;
     let body: string;
     beforeEach(async () => {
-      response = await actions.get('http://localhost:24105/manifest.js');
+      response = await actions.fetch('http://localhost:24105/manifest.js');
       body = await response.text();
     });
 

--- a/test/test-file-server.test.ts
+++ b/test/test-file-server.test.ts
@@ -46,7 +46,7 @@ describe('test file server', () => {
     let response: Response;
     let body: string;
     beforeEach(async () => {
-      response = await actions.get(`http://localhost:${TEST_FILE_PORT}/manifest.js`);
+      response = await actions.fetch(`http://localhost:${TEST_FILE_PORT}/manifest.js`);
       body = await response.text();
     });
 


### PR DESCRIPTION
We currently have a test helper method called `get` which abstracts over the fetch API in some ways, but as we make more complicated requests we end up having to replicate most of the options to fetch anyway. So let's just use fetch directly by adding a thin effection API on top of it.