### PR TITLE
Rename test file server and watcher

### DIFF
--- a/src/manifest-server.ts
+++ b/src/manifest-server.ts
@@ -6,7 +6,7 @@ import { assoc } from 'ramda';
 
 import { Atom } from './orchestrator/atom';
 
-interface TestFileServerOptions {
+interface ManifestServerOptions {
   atom: Atom;
   manifestPath: string;
   port: number;
@@ -21,7 +21,7 @@ function* loadManifest(atom: Atom, outDir: string) {
   atom.update(assoc('manifest', manifest));
 }
 
-export function* createTestFileServer(mail: Mailbox, options: TestFileServerOptions): Operation {
+export function* createManifestServer(mail: Mailbox, options: ManifestServerOptions): Operation {
   // TODO: @precompile this should use node rather than ts-node when running as a compiled package
   let child: ChildProcess = yield forkProcess(
     './bin/parcel-server.ts',
@@ -40,7 +40,7 @@ export function* createTestFileServer(mail: Mailbox, options: TestFileServerOpti
   console.debug("[test files] test files initialized");
 
   yield fork(loadManifest(options.atom, outDir));
-  mail.send({ ready: "test-files" });
+  mail.send({ ready: "manifest-server" });
 
   while(true) {
     yield messages.receive({ type: "update" });
@@ -48,6 +48,6 @@ export function* createTestFileServer(mail: Mailbox, options: TestFileServerOpti
     console.debug("[test files] test files updated");
 
     yield fork(loadManifest(options.atom, outDir));
-    mail.send({ update: "test-files" });
+    mail.send({ update: "manifest-server" });
   }
 }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -6,8 +6,8 @@ import { createCommandServer } from './command-server';
 import { createConnectionServer } from './connection-server';
 import { createAgentServer } from './agent-server';
 import { createAppServer } from './app-server';
-import { createTestFileWatcher } from './test-file-watcher';
-import { createTestFileServer } from './test-file-server';
+import { createManifestGenerator } from './manifest-generator';
+import { createManifestServer } from './manifest-server';
 
 import { Atom } from './orchestrator/atom';
 
@@ -63,15 +63,15 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
     port: options.appPort,
   }));
 
-  yield fork(createTestFileWatcher(mail, {
+  yield fork(createManifestGenerator(mail, {
     files: options.testFiles,
     manifestPath: options.testManifestPath,
   }));
 
   // wait for manifest before starting test file server
-  yield mail.receive({ ready: "manifest" });
+  yield mail.receive({ ready: "manifest-generator" });
 
-  yield fork(createTestFileServer(mail, {
+  yield fork(createManifestServer(mail, {
     atom,
     manifestPath: options.testManifestPath,
     port: options.testFilePort,
@@ -94,7 +94,7 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
       yield mail.receive({ ready: "app" });
     });
     yield fork(function*() {
-      yield mail.receive({ ready: "test-files" });
+      yield mail.receive({ ready: "manifest-server" });
     });
   }
 

--- a/test/manifest-server.test.ts
+++ b/test/manifest-server.test.ts
@@ -8,18 +8,18 @@ import { Context } from 'effection';
 import { Mailbox } from '@effection/events';
 
 import { actions } from './helpers';
-import { createTestFileServer } from '../src/test-file-server';
+import { createManifestServer } from '../src/manifest-server';
 import { OrchestratorState } from '../src/orchestrator/state';
 import { Atom } from '../src/orchestrator/atom';
 
-const TEST_DIR = "./tmp/test-file-server"
-const MANIFEST_PATH = "./tmp/test-file-server/manifest.js"
+const TEST_DIR = "./tmp/manifest-server"
+const MANIFEST_PATH = "./tmp/manifest-server/manifest.js"
 
 const { mkdir, writeFile } = fs.promises;
 
 let TEST_FILE_PORT = 24200;
 
-describe('test file server', () => {
+describe('manifest server', () => {
   let atom: Atom;
   let orchestrator: Mailbox;
 
@@ -32,14 +32,14 @@ describe('test file server', () => {
     orchestrator = new Mailbox();
 
     actions.fork(function*() {
-      yield createTestFileServer(orchestrator, {
+      yield createManifestServer(orchestrator, {
         atom: atom,
         manifestPath: MANIFEST_PATH,
         port: TEST_FILE_PORT
       });
     });
 
-    await actions.receive(orchestrator, { ready: "test-files" });
+    await actions.receive(orchestrator, { ready: "manifest-server" });
   });
 
   describe('retrieving test file manifest', () => {
@@ -69,7 +69,7 @@ describe('test file server', () => {
   describe('updating the manifest and then reading it', () => {
     beforeEach(async () => {
       await writeFile(MANIFEST_PATH, "module.exports = [{ path: 'boo', test: 432 }];");
-      await actions.receive(orchestrator, { update: "test-files" });
+      await actions.receive(orchestrator, { update: "manifest-server" });
     });
 
     it('returns the updated manifest from the state', () => {


### PR DESCRIPTION
This way they are named after what they actually do, and we eliminate the awkward `test` from their names

```
TestFileServer -> ManifestServer
TestFileWatcher -> ManifestGenerator
```