### PR TITLE
Use separate mailboxes for each component's delegates

### DIFF
--- a/bin/start.ts
+++ b/bin/start.ts
@@ -2,14 +2,17 @@ import { fork } from 'effection';
 import { main } from '@effection/node';
 import { Mailbox } from '@effection/events';
 import * as tempy from 'tempy';
+import { setLogLevel } from '../src/log-level';
 
 import { createOrchestrator } from '../src/index';
 
+setLogLevel('info');
+
 main(function*() {
-  let mailbox = new Mailbox();
+  let delegate = new Mailbox();
 
   yield fork(createOrchestrator({
-    delegate: mailbox,
+    delegate,
     appCommand: "yarn",
     appArgs: ["test:app:start"],
     appEnv: {
@@ -26,7 +29,7 @@ main(function*() {
     testManifestPath: tempy.file({ name: 'manifest.js' }),
   }));
 
-  yield mailbox.receive({ ready: "orchestrator" });
+  yield delegate.receive({ status: 'ready' });
 
   console.log("[cli] orchestrator ready!");
 

--- a/src/agent-server.ts
+++ b/src/agent-server.ts
@@ -3,10 +3,11 @@ import { on, Mailbox } from '@effection/events';
 import { ChildProcess, fork as forkProcess } from '@effection/child_process';
 
 interface AgentServerOptions {
+  delegate: Mailbox;
   port: number;
 };
 
-export function* createAgentServer(mail: Mailbox, options: AgentServerOptions): Operation {
+export function* createAgentServer(options: AgentServerOptions): Operation {
   // TODO: @precompile we want this to use a precompiled agent server when used as a package
   let child: ChildProcess = yield forkProcess(
     './bin/parcel-server.ts',
@@ -23,7 +24,7 @@ export function* createAgentServer(mail: Mailbox, options: AgentServerOptions): 
     [message] = yield on(child, "message");
   } while(message.type !== "ready");
 
-  mail.send({ ready: "agent" });
+  options.delegate.send({ status: 'ready' });
 
   yield on(child, "exit");
 }

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -5,6 +5,7 @@ import { Socket } from 'net';
 import * as process from 'process';
 
 interface AppServerOptions {
+  delegate: Mailbox;
   dir?: string;
   command: string;
   args?: string[];
@@ -34,7 +35,7 @@ function isReachable(port: number, options: { timeout: number } = { timeout: 100
   }
 };
 
-export function* createAppServer(mail: Mailbox, options: AppServerOptions): Operation {
+export function* createAppServer(options: AppServerOptions): Operation {
   let child = yield spawn(options.command, options.args || [], {
     cwd: options.dir,
     detached: true,
@@ -50,7 +51,7 @@ export function* createAppServer(mail: Mailbox, options: AppServerOptions): Oper
     yield timeout(100);
   }
 
-  mail.send({ ready: "app" });
+  options.delegate.send({ status: 'ready' });
 
   yield on(child, "exit");
 

--- a/src/command-server/websocket.ts
+++ b/src/command-server/websocket.ts
@@ -10,7 +10,7 @@ import { Connection, sendData } from '../ws';
 
 import { graphql } from '../command-server';
 
-export function handleMessage(mail: Mailbox, atom: Atom): (connection: Connection) => Operation {
+export function handleMessage(delegate: Mailbox, atom: Atom): (connection: Connection) => Operation {
   function* handleQuery(message: QueryMessage, connection: Connection): Operation {
     yield publishQueryResult(message, atom.get(), connection);
 
@@ -20,13 +20,13 @@ export function handleMessage(mail: Mailbox, atom: Atom): (connection: Connectio
   }
 
   function* handleMutation(message: MutationMessage, connection: Connection): Operation {
-    let result = yield graphql(message.mutation, mail, atom.get());
+    let result = yield graphql(message.mutation, delegate, atom.get());
     result.responseId = message.responseId;
     yield sendData(connection, JSON.stringify(result));
   }
 
   function* publishQueryResult(message: QueryMessage, state: OrchestratorState, connection: Connection): Operation {
-    let result = yield graphql(message.query, mail, state);
+    let result = yield graphql(message.query, delegate, state);
     result.responseId = message.responseId;
     yield sendData(connection, JSON.stringify(result));
   }

--- a/src/connection-server.ts
+++ b/src/connection-server.ts
@@ -6,8 +6,8 @@ import { assoc, dissoc, lensPath } from 'ramda';
 import { createSocketServer, Connection, sendData } from './ws';
 import { Atom } from './orchestrator/atom';
 
-
 interface ConnectionServerOptions {
+  delegate: Mailbox;
   atom: Atom;
   port: number;
   proxyPort: number;
@@ -17,7 +17,7 @@ interface ConnectionServerOptions {
 const agentsLens = lensPath(['agents']);
 let counter = 1;
 
-export function* createConnectionServer(mail: Mailbox, options: ConnectionServerOptions): Operation {
+export function* createConnectionServer(options: ConnectionServerOptions): Operation {
   function* handleConnection(connection: Connection): Operation {
     console.debug('[connection] connected');
 
@@ -59,6 +59,6 @@ export function* createConnectionServer(mail: Mailbox, options: ConnectionServer
     }
   }
   yield createSocketServer(options.port, handleConnection, function*() {
-    mail.send({ ready: "connection" });
+    options.delegate.send({ status: "ready" });
   });
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -9,12 +9,13 @@ import * as zlib from 'zlib';
 import { listen } from './http';
 
 interface ProxyOptions {
+  delegate: Mailbox;
   port: number;
   targetPort: number;
   inject?: string;
 };
 
-export function* createProxyServer(mail: Mailbox, options: ProxyOptions): Operation {
+export function* createProxyServer(options: ProxyOptions): Operation {
   function* handleRequest(proxyRes, req, res): Operation {
     console.debug('[proxy]', 'start', req.method, req.url);
     for(let [key, value] of Object.entries(proxyRes.headers)) {
@@ -86,7 +87,7 @@ export function* createProxyServer(mail: Mailbox, options: ProxyOptions): Operat
   try {
 
     yield listen(server, options.port);
-    mail.send({ ready: 'proxy' });
+    options.delegate.send({ status: "ready" });
 
     while(true) {
       let { event, args } = yield events.receive({ event: any("string") });

--- a/test/command-server.test.ts
+++ b/test/command-server.test.ts
@@ -15,19 +15,20 @@ import { Test, SerializableTest } from '../src/test';
 let COMMAND_PORT = 24200;
 
 describe('command server', () => {
-  let mail: Mailbox;
+  let delegate: Mailbox
   let atom: Atom;
 
   beforeEach(async () => {
-    mail = new Mailbox();
+    delegate = new Mailbox();
     atom = new Atom();
 
-    actions.fork(createCommandServer(mail, {
+    actions.fork(createCommandServer({
+      delegate,
       atom,
       port: COMMAND_PORT,
     }));
 
-    await actions.receive(mail, { ready: "command" });
+    await actions.receive(delegate, { status: 'ready' });
   });
 
   describe('fetching the agents at the start', () => {
@@ -52,7 +53,7 @@ describe('command server', () => {
     });
 
     it('sends a message to the orchestrator telling it to start the test run', async () => {
-      let message = await actions.receive(mail, { type: "run" });
+      let message = await actions.receive(delegate, { type: "run" });
       expect(message.type).toEqual("run")
       expect(message.id).toEqual(result.data.run)
     });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -33,7 +33,7 @@ export const actions: Actions = {
     if(!orchestratorPromise) {
       let mail = new Mailbox();
       orchestratorPromise = globalWorld.fork(function*() {
-        yield mail.receive({ ready: "orchestrator" });
+        yield mail.receive({ status: 'ready' });
       });
 
       globalWorld.fork(createOrchestrator({


### PR DESCRIPTION
This way it is much clearer where messages are received. The mailbox is no longer shared between the orchestrator and other parts of the system. The orchestrator's own delegate cannot receive messages from its subcomponents. These changes clarify the following definition of a delegate in this system:

> A delegate is a mailbox where the caller (the outer process) receives messages, and the callee (the component which receives the delegate as an option) sends messages.

We will also want the reverse, pretty soon, where the caller (or someone else) is the sender, and the callee is the recipient. We will want this for the connection server, to initiate test runs in the connected agents, for example. I propose we call this concept "inbox" to separate it from a "delegate".

Depends on #95 