### PR TITLE
Don't cache the proxied app

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -30,6 +30,8 @@ export function* createProxyServer(options: ProxyOptions): Operation {
     if(contentType && contentType.split(';')[0] === 'text/html') {
       res.removeHeader('content-length');
       res.removeHeader('content-encoding');
+      res.removeHeader('cache-control');
+      res.removeHeader('etag');
 
       res.writeHead(proxyRes.statusCode, proxyRes.statusMessage);
 


### PR DESCRIPTION
Motivation
----------

Clients are currently caching the proxied application because it has a very stable URL. This is actually a bad thing, since not only will the application be changing once it is under test, but the script that we inject will be a pointer to a potentially stale `harness.js`

I came across this when extracting the agent server, and the port on which the harness was changing, but we ended up using the old document that pointed to an old harness.

This will only become more pronounced once we move over to running the agent server on a bunch of different ports inside of a bunch of different projects.

Approach
--------

I tried setting a `Cache-Control: no-cache` header on the proxy response, but couldn't get it to stop caching, so this contains a brute force approach of just adding a cache-busting timestamp to the proxy server url.