### PR TITLE
Serve full test tree

### DIFF
--- a/src/command-server.ts
+++ b/src/command-server.ts
@@ -6,7 +6,6 @@ import { graphql as executeGraphql } from 'graphql';
 
 import { listenWS } from './ws';
 import { schema } from './schema';
-import { TestIndex  } from './test';
 import { Atom } from './orchestrator/atom';
 import { OrchestratorState } from './orchestrator/state';
 
@@ -73,22 +72,12 @@ export function graphqlOptions(delegate: Mailbox, state: OrchestratorState) {
     rootValue: {
       echo: ({text}) => text,
       agents: () => Object.values(state.agents),
-      manifest: {
-        url: state.manifest.url,
-        sources: map(({ path }) => path, state.manifest.entries),
-        suite: TestIndex.fromManifest(state.manifest)
-      },
+      manifest: state.manifest,
       run: () => {
         let id = `test-run-${testIdCounter++}`;
         delegate.send({ type: "run", id });
         return id;
       }
     }
-  }
-}
-
-function* map<Input, Output>(fn: ((input: Input) => Output), inputs: Iterable<Input>): Iterable<Output> {
-  for (let input of inputs) {
-    yield fn(input);
   }
 }

--- a/src/manifest-generator.ts
+++ b/src/manifest-generator.ts
@@ -17,7 +17,7 @@ interface ManifestGeneratorOptions {
 function* writeManifest(options: ManifestGeneratorOptions) {
   let files = yield Promise.all(options.files.map((pattern) => promisify(glob)(pattern))).then((l) => l.flat());
 
-  let manifest = "module.exports = [\n";
+  let manifest = "const entries = [\n";
 
   for(let file of files) {
     let filePath = "./" + path.relative(path.dirname(options.manifestPath), file);
@@ -25,6 +25,18 @@ function* writeManifest(options: ManifestGeneratorOptions) {
   }
 
   manifest += "];\n";
+  manifest +=
+`
+module.exports = {
+  sources: entries.map(({ path }) => path),
+  suite: {
+    description: "All Tests",
+    steps: [],
+    assertions: [],
+    children: entries.map(({ test }) => test),
+  }
+}
+`
 
   yield writeFile(options.manifestPath, manifest);
 }

--- a/src/manifest-server.ts
+++ b/src/manifest-server.ts
@@ -17,12 +17,9 @@ function* loadManifest(atom: Atom, outDir: string) {
   let fullPath = path.resolve(outDir, 'manifest.js');
 
   delete require.cache[fullPath];
-  let entries = yield import(fullPath);
+  let manifest = yield import(fullPath);
 
-  atom.update(assoc('manifest', {
-    url: 'http://bigtestmanifest.com', //change me (obvs)
-    entries: entries
-  }));
+  atom.update(assoc('manifest', manifest));
 }
 
 export function* createManifestServer(options: ManifestServerOptions): Operation {

--- a/src/manifest-server.ts
+++ b/src/manifest-server.ts
@@ -17,9 +17,12 @@ function* loadManifest(atom: Atom, outDir: string) {
   let fullPath = path.resolve(outDir, 'manifest.js');
 
   delete require.cache[fullPath];
-  let manifest = yield import(fullPath);
+  let entries = yield import(fullPath);
 
-  atom.update(assoc('manifest', manifest));
+  atom.update(assoc('manifest', {
+    url: 'http://bigtestmanifest.com', //change me (obvs)
+    entries: entries
+  }));
 }
 
 export function* createManifestServer(options: ManifestServerOptions): Operation {

--- a/src/orchestrator/atom.ts
+++ b/src/orchestrator/atom.ts
@@ -8,7 +8,7 @@ import { OrchestratorState } from './state';
 
 export class Atom {
   private state: OrchestratorState = {
-    manifest: [],
+    manifest: {url: '', entries: []},
     agents: {}
   };
 
@@ -18,7 +18,7 @@ export class Atom {
     return this.state;
   }
 
-  update(fn: (OrchestratorState) => OrchestratorState) {
+  update(fn: (state: OrchestratorState) => OrchestratorState) {
     this.state = fn(this.get());
     this.subscriptions.emit('state', this.state);
   }
@@ -33,14 +33,14 @@ export class Atom {
   //eslint-disable-next-line @typescript-eslint/no-explicit-any
   over(lens: any, fn: any) {
     //eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.update(R.over(lens, fn) as any as (OrchestratorState) => OrchestratorState);
+    this.update(R.over(lens, fn) as any as (state: OrchestratorState) => OrchestratorState);
   }
 
   // Ramda Lens types. How do they work?
   //eslint-disable-next-line @typescript-eslint/no-explicit-any
   set(lens: any, value: unknown) {
     //eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.update(R.set(lens, value) as any as (OrchestratorState) => OrchestratorState);
+    this.update(R.set(lens, value) as any as (state: OrchestratorState) => OrchestratorState);
   }
 
   *next(): Operation {

--- a/src/orchestrator/atom.ts
+++ b/src/orchestrator/atom.ts
@@ -8,7 +8,15 @@ import { OrchestratorState } from './state';
 
 export class Atom {
   private state: OrchestratorState = {
-    manifest: {url: '', entries: []},
+    manifest: {
+      sources: [],
+      suite: {
+        description: "empty",
+        steps: [],
+        assertions: [],
+        children: []
+      },
+    },
     agents: {}
   };
 

--- a/src/orchestrator/state.ts
+++ b/src/orchestrator/state.ts
@@ -1,4 +1,4 @@
-import { Test } from '../test';
+import { Manifest } from '../test';
 
 export type AgentState = {
   identifier: string;
@@ -21,12 +21,7 @@ export type AgentState = {
   };
 }
 
-export type ManifestEntry = {
-  path: string;
-  test: Test;
-}
-
 export type OrchestratorState = {
   agents: Record<string, AgentState>;
-  manifest: ManifestEntry[];
+  manifest: Manifest;
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -43,14 +43,11 @@ type Engine {
 }
 
 type Manifest {
-  url: String!
   sources: [String!]!
   suite: Test!
 }
 
 type Test {
-  id: String!
-  path: [String!]!
   description: String!
   steps: [Step!]!
   assertions: [Assertion!]!

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -6,7 +6,7 @@ scalar TestRunId
 type Query {
   echo(text: String!): String
   agents: [Agent!]!
-  manifest: [ManifestEntry!]!
+  manifest: Manifest!
 }
 
 type Mutation {
@@ -42,10 +42,28 @@ type Engine {
   version: String!
 }
 
-type ManifestEntry {
-  path: String!
-  test: Test!
+type Manifest {
+  url: String!
+  sources: [String!]!
+  suite: Test!
 }
 
-scalar Test
+type Test {
+  id: String!
+  path: [String!]!
+  description: String!
+  steps: [Step!]!
+  assertions: [Assertion!]!
+  children: [Test!]!
+}
+
+type Step {
+  path: [String!]!
+  description: String!
+}
+
+type Assertion {
+  path: [String!]!
+  description: String!
+}
 `);

--- a/src/test.ts
+++ b/src/test.ts
@@ -29,8 +29,3 @@ export interface Manifest {
   sources: string[];
   suite: Test;
 }
-
-export interface ManifestEntry {
-  path: string;
-  test: Test;
-}

--- a/src/test.ts
+++ b/src/test.ts
@@ -26,63 +26,11 @@ export interface Check {
 export type Context = Record<string, unknown>;
 
 export interface Manifest {
-  url: string;
-  entries: ManifestEntry[];
+  sources: string[];
+  suite: Test;
 }
 
-export type ManifestEntry = {
+export interface ManifestEntry {
   path: string;
   test: Test;
-}
-
-
-/**
- * Used to take the raw data of a manifest and provide a "smart" API
- * over the. Specifically, to support operations like finding a Test
- * by id or path.
- */
-export class TestIndex implements Test {
-
-  static separator = ' > ';
-
-  constructor(private test: Test, public path: string[]) {}
-
-  static fromManifest(manifest: Manifest): TestIndex {
-    return new TestIndex({
-      description: 'All Tests',
-      steps: [],
-      assertions: [],
-      children: map(({ test }) => new TestIndex(test, [test.description]), manifest.entries)
-    }, []);
-  }
-
-  get id() { return this.path.join(TestIndex.separator); }
-  get description() { return this.test.description; }
-  get steps() { return this.test.steps; }
-  get assertions() { return this.test.assertions; }
-  get children() { return map(test => new TestIndex(test, this.path.concat(test.description)), this.test.children); }
-
-
-  findByPath(path: string[], fullPathId = path.join(TestIndex.separator)): TestIndex {
-    if (path.length === 0) {
-      return this;
-    }
-    let [description, ...rest] = path;
-    for (let child of this.children) {
-      if (child.description === description) {
-        return child.findByPath(rest, fullPathId);
-      }
-    }
-    throw new Error(`IndexError: when looking up path '${fullPathId}', could not find '${this.path.concat(description).join(TestIndex.separator)}'`)
-  }
-
-  findById(id: string): TestIndex {
-    return this.findByPath(id.split(TestIndex.separator));
-  }
-}
-
-function* map<Input, Output>(fn: ((input: Input) => Output), inputs: Iterable<Input>): Iterable<Output> {
-  for (let input of inputs) {
-    yield fn(input);
-  }
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -25,11 +25,64 @@ export interface Check {
 
 export type Context = Record<string, unknown>;
 
-export interface SerializableTest {
-  description: string;
-  steps: Array<{ description: string }>;
-  assertions: Array<{ description: string }>;
-  children: Array<SerializableTest>;
+export interface Manifest {
+  url: string;
+  entries: ManifestEntry[];
 }
 
-export type Manifest = Iterable<{ path: string; test: SerializableTest }>;
+export type ManifestEntry = {
+  path: string;
+  test: Test;
+}
+
+
+/**
+ * Used to take the raw data of a manifest and provide a "smart" API
+ * over the. Specifically, to support operations like finding a Test
+ * by id or path.
+ */
+export class TestIndex implements Test {
+
+  static separator = ' > ';
+
+  constructor(private test: Test, public path: string[]) {}
+
+  static fromManifest(manifest: Manifest): TestIndex {
+    return new TestIndex({
+      description: 'All Tests',
+      steps: [],
+      assertions: [],
+      children: map(({ test }) => new TestIndex(test, [test.description]), manifest.entries)
+    }, []);
+  }
+
+  get id() { return this.path.join(TestIndex.separator); }
+  get description() { return this.test.description; }
+  get steps() { return this.test.steps; }
+  get assertions() { return this.test.assertions; }
+  get children() { return map(test => new TestIndex(test, this.path.concat(test.description)), this.test.children); }
+
+
+  findByPath(path: string[], fullPathId = path.join(TestIndex.separator)): TestIndex {
+    if (path.length === 0) {
+      return this;
+    }
+    let [description, ...rest] = path;
+    for (let child of this.children) {
+      if (child.description === description) {
+        return child.findByPath(rest, fullPathId);
+      }
+    }
+    throw new Error(`IndexError: when looking up path '${fullPathId}', could not find '${this.path.concat(description).join(TestIndex.separator)}'`)
+  }
+
+  findById(id: string): TestIndex {
+    return this.findByPath(id.split(TestIndex.separator));
+  }
+}
+
+function* map<Input, Output>(fn: ((input: Input) => Output), inputs: Iterable<Input>): Iterable<Output> {
+  for (let input of inputs) {
+    yield fn(input);
+  }
+}

--- a/test/command-server.test.ts
+++ b/test/command-server.test.ts
@@ -145,23 +145,23 @@ describe('command server', () => {
       };
 
       atom.update(assoc('manifest', {
-        url: 'http://bigmanifest.com',
-        entries: [
-          { path: "foo.js", test: test1 },
-          { path: "bar.js", test: test2 }
-        ],
+        sources: ["foo.js", "bar.js"],
+        suite: {
+          description: "All Tests",
+          steps: [],
+          assertions: [],
+          children: [test1, test2]
+        },
       }));
       result = await query(`
 manifest {
-  url
   sources
   suite {
-    id
     description
     children {
-      id description
+      description
       children {
-        id description
+        description
       }
     }
   }
@@ -187,17 +187,13 @@ manifest {
         data: {
           manifest: {
             suite: {
-              id: "",
               description: "All Tests",
               children: [{
-                id: "First Test",
                 description: "First Test",
                 children: [{
-                  id: "First Test > Son of First Test",
                   description: "Son of First Test"
                 }]
               }, {
-                id: "Second Test",
                 description: "Second Test"
               }]
             }

--- a/test/command-server.test.ts
+++ b/test/command-server.test.ts
@@ -204,14 +204,6 @@ manifest {
           }
         }
       })
-      // let [first, second]: Array<> = result.data.manifest.map(m => JSON.parse(m.test));
-
-      // expect(first.description).toEqual('First Test');
-      // expect(first.steps).toEqual([ { description: "Do the thing" }]);
-      // expect(first.children).toMatchObject([ { description: "Son of First Test" }]);
-      // expect(first.assertions).toMatchObject([ { description: "It did the thing" }]);
-
-      // expect(second.description).toEqual('Second Test');
     });
   });
 

--- a/test/manifest-server.test.ts
+++ b/test/manifest-server.test.ts
@@ -62,7 +62,7 @@ describe('manifest server', () => {
 
   describe('reading manifest from state on start', () => {
     it('returns the manifest from the state', () => {
-      let { manifest: [ first ] } = atom.get();
+      let { manifest: { entries: [ first ] } }= atom.get();
       expect(first).toEqual({ path: 'someworld', test: 123 });
     });
   });
@@ -74,7 +74,7 @@ describe('manifest server', () => {
     });
 
     it('returns the updated manifest from the state', () => {
-      expect(atom.get().manifest[0]).toEqual({ path: 'boo', test: 432 });
+      expect(atom.get().manifest.entries).toEqual([{ path: 'boo', test: 432 }]);
     });
   });
 });

--- a/test/manifest-server.test.ts
+++ b/test/manifest-server.test.ts
@@ -26,7 +26,7 @@ describe('manifest server', () => {
   beforeEach((done) => rmrf(TEST_DIR, done));
   beforeEach(async () => {
     await mkdir(TEST_DIR, { recursive: true });
-    await writeFile(MANIFEST_PATH, "module.exports = [{ path: 'someworld', test: 123 }];");
+    await writeFile(MANIFEST_PATH, "module.exports = { sources: [ 'boo' ] };");
 
     atom = new Atom();
     delegate = new Mailbox();
@@ -56,25 +56,25 @@ describe('manifest server', () => {
     });
 
     it('serves the manifest', () => {
-      expect(body).toContain('someworld');
+      expect(body).toContain('boo');
     });
   });
 
   describe('reading manifest from state on start', () => {
     it('returns the manifest from the state', () => {
-      let { manifest: { entries: [ first ] } }= atom.get();
-      expect(first).toEqual({ path: 'someworld', test: 123 });
+      let { manifest: { sources: [ first ] } } = atom.get() ;
+      expect(first).toEqual('boo');
     });
   });
 
   describe('updating the manifest and then reading it', () => {
     beforeEach(async () => {
-      await writeFile(MANIFEST_PATH, "module.exports = [{ path: 'boo', test: 432 }];");
+      await writeFile(MANIFEST_PATH, "module.exports = { sources: ['foo' ] };");
       await actions.receive(delegate, { event: "update" });
     });
 
     it('returns the updated manifest from the state', () => {
-      expect(atom.get().manifest.entries).toEqual([{ path: 'boo', test: 432 }]);
+      expect(atom.get().manifest.sources).toEqual(['foo']);
     });
   });
 });


### PR DESCRIPTION
closes #94 

Motivation
----------

We had previously made the decision to serialize the tree representing the test in the GraphQL API as JSON in order to facilitate fetching it without resorting to complicated query generation via fragments or otherwise. However, the moment we needed to actually work with the tree by sending back test results in order to match the tree, it became clear that we'd want to have the result structure match the tree structure.

Approach
--------

This goes back to serving the test tree as a strongly typed GraphQL structure that preserves the recursive nature. In addition to restoring the tree, each test is now annotated with both a `path` (Array) and an `id` (String) that are unique to that test node. This can be used to match test results with tests, and also to specify a subset of tests to run.

Finally, since it was easier to do at this point rather than not, the `Manifest` interface was updated to account for unique identification of manifests by URL.

Screenshots
------------

![image](https://user-images.githubusercontent.com/4205/74662494-a4644880-515f-11ea-82b0-6d8da7fa051c.png)


Open Questions
--------------

- Would it make sense to have the server somehow integrate active test runs and results along with the test tree? That would certainly make it easier for clients to display results rather than do the work to interleaving them on their end.