### PR TITLE
Split manifest server into separate builder and server

### DIFF
--- a/bin/parcel-server.ts
+++ b/bin/parcel-server.ts
@@ -2,21 +2,17 @@ import 'module-alias/register';
 import { main } from '@effection/node';
 import { createParcelServer } from '../src/parcel-server';
 import * as yargs from 'yargs';
-import * as tempy from 'tempy';
-
-const DIST_PATH = tempy.directory();
 
 yargs
   .command('$0 [files..]', 'run the parcel server', () => {}, (argv) => {
     main(createParcelServer(argv.files as string[], { port: argv.port as number }, {
-      outDir: DIST_PATH,
+      outDir: argv.outDir,
       outFile: argv.outFile,
       global: argv.global,
     }));
   })
   .option('port', {
     alias: 'p',
-    demandOption: true,
     type: 'number',
     describe: 'the port to run on',
   })
@@ -24,6 +20,11 @@ yargs
     alias: 'o',
     type: 'string',
     describe: 'set the output filename for the application entry point',
+  })
+  .option('out-dir', {
+    alias: 'd',
+    type: 'string',
+    describe: 'set the output directory.'
   })
   .option('global', {
     type: 'string',

--- a/bin/start.ts
+++ b/bin/start.ts
@@ -25,9 +25,10 @@ main(function*() {
     connectionPort: 24003,
     agentPort: 24004,
     externalAgentServerURL: process.env['BIGTEST_AGENT_SERVER_URL'],
-    testFilePort: 24005,
+    manifestPort: 24005,
     testFiles: ["./test/fixtures/*.t.ts"],
-    testManifestPath: tempy.file({ name: 'manifest.js' }),
+    manifestPath: tempy.file({ name: 'manifest.js' }),
+    manifestDistPath: tempy.directory(),
   }));
 
   yield delegate.receive({ status: 'ready' });

--- a/src/command-server.ts
+++ b/src/command-server.ts
@@ -1,5 +1,5 @@
-import { Operation, fork } from 'effection';
-import { on, Mailbox } from '@effection/events';
+import { Operation } from 'effection';
+import { Mailbox } from '@effection/events';
 import { express, Express } from '@effection/express';
 import * as graphqlHTTP from 'express-graphql';
 import { graphql as executeGraphql } from 'graphql';

--- a/src/connection-server.ts
+++ b/src/connection-server.ts
@@ -11,7 +11,7 @@ interface ConnectionServerOptions {
   atom: Atom;
   port: number;
   proxyPort: number;
-  testFilePort: number;
+  manifestPort: number;
 };
 
 const agentsLens = lensPath(['agents']);
@@ -37,7 +37,7 @@ export function* createConnectionServer(options: ConnectionServerOptions): Opera
       yield sendData(connection, JSON.stringify({
         type: "open",
         url: `http://localhost:${options.proxyPort}`,
-        manifest: `http://localhost:${options.testFilePort}/manifest.js`
+        manifest: `http://localhost:${options.manifestPort}/manifest.js`
       }));
     });
 

--- a/src/manifest-builder.ts
+++ b/src/manifest-builder.ts
@@ -1,0 +1,53 @@
+import { fork, Operation } from 'effection';
+import { Mailbox } from '@effection/events';
+import { ChildProcess, fork as forkProcess } from '@effection/child_process';
+import * as path from 'path';
+import { assoc } from 'ramda';
+
+import { Atom } from './orchestrator/atom';
+
+interface ManifestBuilderOptions {
+  delegate: Mailbox;
+  atom: Atom;
+  manifestPath: string;
+  distPath: string;
+};
+
+function* loadManifest(atom: Atom, manifestPath: string) {
+  delete require.cache[manifestPath];
+  let manifest = yield import(manifestPath);
+
+  atom.update(assoc('manifest', manifest));
+}
+
+export function* createManifestBuilder(options: ManifestBuilderOptions): Operation {
+  // TODO: @precompile this should use node rather than ts-node when running as a compiled package
+  let child: ChildProcess = yield forkProcess(
+    './bin/parcel-server.ts',
+    ['--out-dir', options.distPath, '--out-file', 'manifest.js', '--global', '__bigtestManifest', options.manifestPath],
+    {
+      execPath: 'ts-node',
+      execArgv: [],
+      stdio: ['pipe', 'pipe', 'pipe', 'ipc']
+    }
+  );
+
+  let messages = yield Mailbox.watch(child, "message", ({ args: [message] }) => message);
+
+  let { options: { outDir } } = yield messages.receive({ type: "ready" });
+
+  let manifestPath = path.resolve(outDir, 'manifest.js');
+
+  yield fork(loadManifest(options.atom, manifestPath));
+  console.debug("[manifest builder] manifest ready");
+  options.delegate.send({ status: "ready", path: manifestPath });
+
+  while(true) {
+    yield messages.receive({ type: "update" });
+
+    yield fork(loadManifest(options.atom, manifestPath));
+
+    console.debug("[manifest builder] manifest updated");
+    options.delegate.send({ event: "update", path: manifestPath });
+  }
+}

--- a/src/manifest-server.ts
+++ b/src/manifest-server.ts
@@ -1,54 +1,22 @@
-import { fork, Operation } from 'effection';
+import { Operation } from 'effection';
 import { Mailbox } from '@effection/events';
-import { ChildProcess, fork as forkProcess } from '@effection/child_process';
-import * as path from 'path';
-import { assoc } from 'ramda';
-
-import { Atom } from './orchestrator/atom';
+import { static as staticMiddleware } from 'express';
+import { express } from '@effection/express';
 
 interface ManifestServerOptions {
   delegate: Mailbox;
-  atom: Atom;
-  manifestPath: string;
+  path: string;
   port: number;
 };
 
-function* loadManifest(atom: Atom, outDir: string) {
-  let fullPath = path.resolve(outDir, 'manifest.js');
-
-  delete require.cache[fullPath];
-  let manifest = yield import(fullPath);
-
-  atom.update(assoc('manifest', manifest));
-}
-
 export function* createManifestServer(options: ManifestServerOptions): Operation {
-  // TODO: @precompile this should use node rather than ts-node when running as a compiled package
-  let child: ChildProcess = yield forkProcess(
-    './bin/parcel-server.ts',
-    ['-p', `${options.port}`, '--out-file', 'manifest.js', '--global', '__bigtestManifest', options.manifestPath],
-    {
-      execPath: 'ts-node',
-      execArgv: [],
-      stdio: ['pipe', 'pipe', 'pipe', 'ipc']
-    }
-  );
+  let app = express();
 
-  let messages = yield Mailbox.watch(child, "message", ({ args: [message] }) => message);
+  app.use(staticMiddleware(options.path));
 
-  let { options: { outDir } } = yield messages.receive({ type: "ready" });
+  yield app.listen(options.port);
 
-  console.debug("[test files] test files initialized");
-
-  yield fork(loadManifest(options.atom, outDir));
   options.delegate.send({ status: "ready" });
 
-  while(true) {
-    yield messages.receive({ type: "update" });
-
-    console.debug("[test files] test files updated");
-
-    yield fork(loadManifest(options.atom, outDir));
-    options.delegate.send({ event: "update" });
-  }
+  yield
 }

--- a/src/parcel-server.ts
+++ b/src/parcel-server.ts
@@ -7,7 +7,7 @@ import { EventEmitter } from 'events';
 import { listen } from './http';
 
 interface ParcelServerOptions {
-  port: number;
+  port?: number;
 };
 
 export function* createParcelServer(entryPoints: string[], options: ParcelServerOptions, parcelOptions?: ParcelOptions): Operation {
@@ -19,7 +19,9 @@ export function* createParcelServer(entryPoints: string[], options: ParcelServer
   let server = createServer(middleware)
 
   try {
-    yield listen(server, options.port);
+    if(options.port) {
+      yield listen(server, options.port);
+    }
 
     yield events.receive({ event: "buildEnd" });
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -43,12 +43,13 @@ export const actions: Actions = {
         appDir: "test/app",
         appPort: 24100,
         testFiles: ["test/fixtures/*.t.js"],
-        testManifestPath: "test/manifest.js",
+        manifestPath: "./tmp/orchestrator/src/manifest.js",
+        manifestDistPath: "./tmp/orchestrator/dist",
+        manifestPort: 24105,
         proxyPort: 24101,
         commandPort: 24102,
         connectionPort: 24103,
         agentPort: 24104,
-        testFilePort: 24105,
       }));
     }
     return orchestratorPromise;

--- a/test/manifest-builder.test.ts
+++ b/test/manifest-builder.test.ts
@@ -1,61 +1,55 @@
 import { describe, beforeEach, it } from 'mocha';
 import * as expect from 'expect';
+import * as path from 'path';
 import * as rmrf from 'rimraf';
 import * as fs from 'fs';
 
 import { Response } from 'node-fetch';
-import { Context } from 'effection';
 import { Mailbox } from '@effection/events';
 
 import { actions } from './helpers';
-import { createManifestServer } from '../src/manifest-server';
-import { OrchestratorState } from '../src/orchestrator/state';
+import { createManifestBuilder } from '../src/manifest-builder';
 import { Atom } from '../src/orchestrator/atom';
 
-const TEST_DIR = "./tmp/manifest-server"
-const MANIFEST_PATH = "./tmp/manifest-server/manifest.js"
+const TEST_DIR = "./tmp/manifest-builder"
+const SRC_DIR = `${TEST_DIR}/src`
+const DIST_DIR = `${TEST_DIR}/dist`
+const MANIFEST_PATH = `${SRC_DIR}/manifest.js`
 
-const { mkdir, writeFile } = fs.promises;
+const { mkdir, writeFile, readFile } = fs.promises;
 
-let TEST_FILE_PORT = 24200;
-
-describe('manifest server', () => {
+describe('manifest builder', () => {
   let atom: Atom;
   let delegate: Mailbox;
+  let resultPath: string;
 
   beforeEach((done) => rmrf(TEST_DIR, done));
   beforeEach(async () => {
-    await mkdir(TEST_DIR, { recursive: true });
+    await mkdir(SRC_DIR, { recursive: true });
     await writeFile(MANIFEST_PATH, "module.exports = { sources: [ 'boo' ] };");
 
     atom = new Atom();
     delegate = new Mailbox();
 
     actions.fork(function*() {
-      yield createManifestServer({
+      yield createManifestBuilder({
         delegate,
         atom,
         manifestPath: MANIFEST_PATH,
-        port: TEST_FILE_PORT
+        distPath: DIST_DIR,
       });
     });
 
-    await actions.receive(delegate, { status: 'ready' });
+    resultPath = (await actions.receive(delegate, { status: 'ready' })).path;
   });
 
-  describe('retrieving test file manifest', () => {
-    let response: Response;
+  describe('retrieving test file manifest from disk', () => {
     let body: string;
     beforeEach(async () => {
-      response = await actions.fetch(`http://localhost:${TEST_FILE_PORT}/manifest.js`);
-      body = await response.text();
+      body = await readFile(path.resolve(DIST_DIR, resultPath), 'utf8')
     });
 
-    it('responds successfully', () => {
-      expect(response.ok).toEqual(true);
-    });
-
-    it('serves the manifest', () => {
+    it('contains the built manifest', () => {
       expect(body).toContain('boo');
     });
   });


### PR DESCRIPTION
Working towards #93

If we copy the manifest so we get uniquely identified manifests then we need to have control over the static file server which serves these files. This splits the current manifest server into two separate parts, a builder which uses parcel to generate the files, these are just stored to disk and not actually served, and a server which is just a static file server using express.